### PR TITLE
global: Invenio-Records-REST capitalisation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,3 +29,4 @@ REST API for invenio-records.
 
 - Nicolas Harraudeau <nicolas.harraudeau@cern.ch>
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+- Tibor Simko <tibor.simko@cern.ch>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,8 +33,8 @@ is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-Invenio-Records-Rest could always use more documentation, whether as part of the
-official Invenio-Records-Rest docs, in docstrings, or even on the web in blog posts,
+Invenio-Records-REST could always use more documentation, whether as part of the
+official Invenio-Records-REST docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@
     waive the privileges and immunities granted to it by virtue of its status
     as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-=========================
- Invenio-Records-Rest
-=========================
+======================
+ Invenio-Records-REST
+======================
 
 .. image:: https://img.shields.io/travis/inveniosoftware/invenio-records-rest.svg
         :target: https://travis-ci.org/inveniosoftware/invenio-records-rest

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
-================================
- Invenio-Records-Rest v1.0.0
-================================
+=============================
+ Invenio-Records-REST v1.0.0
+=============================
 
-Invenio-Records-Rest v1.0.0 was released on November 1, 2015.
+Invenio-Records-REST v1.0.0 was released on November 1, 2015.
 
 About
 -----
@@ -26,7 +26,7 @@ Documentation
 
    http://pythonhosted.org/invenio-records-rest/
 
-Happy hacking and thanks for flying Invenio-Records-Rest.
+Happy hacking and thanks for flying Invenio-Records-REST.
 
 | Invenio Development Team
 |   Email: info@invenio-software.org

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Invenio-Records-Rest'
+project = u'Invenio-Records-REST'
 copyright = u'2015, CERN'
 author = u'CERN'
 
@@ -316,7 +316,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'invenio-records-rest', u'Invenio-Records-Rest Documentation',
+    (master_doc, 'invenio-records-rest', u'Invenio-Records-REST Documentation',
      author, 'invenio-records-rest', 'REST API for invenio-records.',
      'Miscellaneous'),
 ]

--- a/invenio_records_rest/ext.py
+++ b/invenio_records_rest/ext.py
@@ -30,7 +30,7 @@ from .restful import blueprint
 
 
 class InvenioRecordsREST(object):
-    """Invenio-Records-Rest extension."""
+    """Invenio-Records-REST extension."""
 
     def __init__(self, app=None):
         """Extension initialization."""

--- a/invenio_records_rest/version.py
+++ b/invenio_records_rest/version.py
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Version information for Invenio-Records-Rest.
+"""Version information for Invenio-Records-REST.
 
 This file is imported by ``invenio_records_rest.__init__``,
 and parsed by ``setup.py``.


### PR DESCRIPTION
* Standardises human package name from `-Rest` to `-REST` following the
  usual practices.

* Amends "overhanging" ReStructuredText headlines.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>