### PR TITLE
global: usage fixes

### DIFF
--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Invenio-Records-REST configuration."""
+
+from __future__ import absolute_import, print_function
+
+RECORDS_REST_ENDPOINTS = dict(
+    recid=dict(
+        pid_type='recid',
+        pid_minter='recid_minter',
+        pid_fetcher='recid_fetcher',
+        search_index='records',
+        search_type=None,
+        record_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':record_to_json_serializer'),
+        },
+        search_serializers={
+            'application/json': ('invenio_records_rest.serializers'
+                                 ':search_to_json_serializer'),
+        },
+        list_route='/records/',
+        item_route='/records/<pid_value>',
+    ),
+)
+
+RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY = None
+RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY = None
+RECORDS_REST_DEFAULT_UPDATE_PERMISSION_FACTORY = None
+RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY = None

--- a/invenio_records_rest/ext.py
+++ b/invenio_records_rest/ext.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 from werkzeug.utils import cached_property, import_string
 
+from . import config
 from .views import create_blueprint
 
 
@@ -48,9 +49,8 @@ class _RecordRESTState(object):
     def read_permission_factory(self):
         """Load default read permission factory."""
         if self._read_permission_factory is None:
-            imp = self.app.config[
-                'RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY'
-            ]
+            imp = self.app.config.get(
+                'RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY')
             self._read_permission_factory = import_string(imp) if imp else None
         return self._read_permission_factory
 
@@ -58,9 +58,8 @@ class _RecordRESTState(object):
     def create_permission_factory(self):
         """Load default create permission factory."""
         if self._create_permission_factory is None:
-            imp = self.app.config[
-                'RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY'
-            ]
+            imp = self.app.config.get(
+                'RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY')
             self._create_permission_factory = import_string(imp) \
                 if imp else None
         return self._create_permission_factory
@@ -69,9 +68,8 @@ class _RecordRESTState(object):
     def update_permission_factory(self):
         """Load default update permission factory."""
         if self._update_permission_factory is None:
-            imp = self.app.config[
-                'RECORDS_REST_DEFAULT_UPDATE_PERMISSION_FACTORY'
-            ]
+            imp = self.app.config.get(
+                'RECORDS_REST_DEFAULT_UPDATE_PERMISSION_FACTORY')
             self._update_permission_factory = import_string(imp) \
                 if imp else None
         return self._update_permission_factory
@@ -80,30 +78,11 @@ class _RecordRESTState(object):
     def delete_permission_factory(self):
         """Load default delete permission factory."""
         if self._delete_permission_factory is None:
-            imp = self.app.config[
-                'RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY'
-            ]
+            imp = self.app.config.get(
+                'RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY')
             self._delete_permission_factory = import_string(imp) \
                 if imp else None
         return self._delete_permission_factory
-
-    @cached_property
-    def search_index(self):
-        """Record search index."""
-        if self._search_index is None:
-            self._search_index = self.app.config[
-                'SEARCH_INDEX_DEFAULT'
-            ]
-        return self._search_index
-
-    @cached_property
-    def search_type(self):
-        """Record search type."""
-        if self._search_type is None:
-            self._search_type = self.app.config[
-                'SEARCH_DOC_TYPE_DEFAULT'
-            ]
-        return self._search_type
 
 
 class InvenioRecordsREST(object):
@@ -126,23 +105,6 @@ class InvenioRecordsREST(object):
     def init_config(self, app):
         """Initialize configuration."""
         # Set up API endpoints for records.
-        app.config.setdefault(
-            'RECORDS_REST_ENDPOINTS',
-            dict(
-                recid=dict(
-                    pid_type='recid',
-                    pid_minter='recid_minter',
-                    pid_fetcher='recid_fetcher',
-                    record_serializers={
-                        'application/json': ('invenio_records_rest.serializers'
-                                             ':record_to_json_serializer'),
-                    },
-                    search_serializers={
-                        'application/json': ('invenio_records_rest.serializers'
-                                             ':search_to_json_serializer'),
-                    },
-                    list_route='/records/',
-                    item_route='/records/<pid_value>',
-                ),
-            )
-        )
+        for k in dir(config):
+            if k.startswith('RECORDS_REST_'):
+                app.config.setdefault(k, getattr(config, k))

--- a/invenio_records_rest/serializers.py
+++ b/invenio_records_rest/serializers.py
@@ -137,22 +137,21 @@ def record_hit_formatter(hit, pid_fetcher):
     fetched_pid = pid_fetcher(hit['_id'], hit['_source'])
     self_link = record_self_link(fetched_pid.pid_value, fetched_pid.pid_type,
                                  hit['_source'], _external=True)
-    source = hit['_source']
-    created = source['_created']
-    updated = source['_updated']
-    revision = hit['_version']
-    for key in ['_created', '_updated']:
-        del source[key]
-    return {
+    data = {
         'id': fetched_pid.pid_value,
-        'metadata': source,
+        'metadata': hit['_source'],
         'links': {
             'self': self_link
         },
-        'created': created,
-        'updated': updated,
-        'revision': revision,
+        'revision': hit['_version'],
     }
+
+    for key in ['_created', '_updated']:
+        if key in data['metadata']:
+            data[key[1:]] = data['metadata'][key]
+            del data['metadata'][key]
+
+    return data
 
 search_to_json_serializer = search_to_json_serializer_factory(
     hit_formatter=record_hit_formatter

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -104,6 +104,7 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
     assert pid_type
     assert search_serializers
     assert record_serializers
+    assert search_index
 
     read_permission_factory = import_string(read_permission_factory_imp) \
         if read_permission_factory_imp else None
@@ -269,12 +270,9 @@ class RecordsListResource(ContentNegotiatedMethodView):
             if sort_key:
                 query = query.sort(sort_key)
 
-        search_index = self.search_index or current_records_rest.search_index
-        search_type = self.search_type or current_records_rest.search_type
-
         response = current_search_client.search(
-            index=search_index,
-            doc_type=search_type,
+            index=self.search_index,
+            doc_type=self.search_type,
             body=query.body,
             version=True,
         )

--- a/tests/access_records.py
+++ b/tests/access_records.py
@@ -99,8 +99,8 @@ def index_record_modification(sender, changes):
     for id in records_to_index:
         if id not in records_to_delete:
             current_search_client.index(
-                index=current_app.config['SEARCH_INDEX_DEFAULT'],
-                doc_type=current_app.config['SEARCH_DOC_TYPE_DEFAULT'],
+                index='invenio_records_rest_test_index',
+                doc_type='record',
                 id=id,
                 body=records_to_index[id].body,
                 version=records_to_index[id].version,
@@ -108,8 +108,8 @@ def index_record_modification(sender, changes):
             )
     for id in records_to_delete:
         current_search_client.delete(
-            index=current_app.config['SEARCH_INDEX_DEFAULT'],
-            doc_type=current_app.config['SEARCH_DOC_TYPE_DEFAULT'],
+            index='invenio_records_rest_test_index',
+            doc_type='record',
             id=id,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ from invenio_access import InvenioAccess
 from invenio_access.models import ActionUsers
 from invenio_db import InvenioDB, db
 from invenio_records_rest import InvenioRecordsREST
+from invenio_records_rest import config
 from invenio_search import InvenioSearch, current_search_client
 
 from access_records import filter_record_access_query_enhancer, \
@@ -71,16 +72,18 @@ def app(request):
         SQLALCHEMY_DATABASE_URI=os.environ.get(
             'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'
         ),
+        RECORDS_REST_ENDPOINTS=config.RECORDS_REST_ENDPOINTS,
         # No permission checking
         RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_UPDATE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_SEARCH_INDEX=es_index,
-        SEARCH_INDEX_DEFAULT=es_index,
-        SEARCH_AUTOINDEX=[],
         SEARCH_QUERY_ENHANCERS=[filter_record_access_query_enhancer],
+        SEARCH_AUTOINDEX=[],
     )
+    app.config['RECORDS_REST_ENDPOINTS']['recid']['search_index'] = es_index
+
     # update the application with the configuration provided by the test
     if hasattr(request, 'param') and 'config' in request.param:
         app.config.update(**request.param['config'])

--- a/tests/test_invenio_records_rest.py
+++ b/tests/test_invenio_records_rest.py
@@ -953,6 +953,8 @@ custom_search_to_json_serializer = search_to_json_serializer_factory(
                 'pid_type': 'recid',
                 'pid_minter': 'recid_minter',
                 'pid_fetcher': 'recid_fetcher',
+                'search_index': 'invenio_records_rest_test_index',
+                'search_type': 'record',
                 'record_serializers': {
                     'application/json': 'invenio_records_rest.serializers'
                     ':record_to_json_serializer',


### PR DESCRIPTION
* Fixes problem with undefined permission factory configuration
  variables.

* Forces search index to be specified in RECORDS_REST_ENDPOINTS.
  (closes #21)

* Fixes bug which did not allow for an empty document type.

* Fixes problem with _created/_updated being required in record source.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>