### PR TITLE
tests: SEARCH_AUTOINDEX removal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ install_requires = [
     'invenio-rest>=1.0.0a4',
     'invenio-records>=1.0.0a7',
     'invenio-pidstore>=1.0.0a3',
-    'invenio-search>=v1.0.0a3',
+    'invenio-search>=v1.0.0a4',
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,6 @@ def app(request):
         RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_SEARCH_INDEX=es_index,
         SEARCH_QUERY_ENHANCERS=[filter_record_access_query_enhancer],
-        SEARCH_AUTOINDEX=[],
     )
     app.config['RECORDS_REST_ENDPOINTS']['recid']['search_index'] = es_index
 
@@ -122,6 +121,7 @@ def app(request):
 
 @pytest.fixture()
 def accounts(app):
+    """Accounts."""
     app.config.update(
         WTF_CSRF_ENABLED=False,
         SECRET_KEY='CHANGEME',


### PR DESCRIPTION
* Removes obsolete configuration. (closes #23)
  (see inveniosoftware/invenio-search@cc05a96)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>