### PR TITLE
global: PID resolver as URL converter

### DIFF
--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -53,7 +53,7 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
         },
         list_route='/records/',
-        item_route='/records/<pid_value>',
+        item_route='/records/<pid(recid):pid_value>',
         default_media_type='application/json',
         max_result_window=10000,
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ from sqlalchemy_utils.functions import create_database, database_exists
 
 from invenio_records_rest import InvenioRecordsREST, config
 from invenio_records_rest.facets import terms_filter
+from invenio_records_rest.utils import PIDConverter
 
 
 class TestSearch(RecordsSearch):
@@ -156,6 +157,8 @@ def app(request, search_class):
         if 'endpoint' in request.param:
             app.config['RECORDS_REST_ENDPOINTS']['recid'].update(
                 request.param['endpoint'])
+
+    app.url_map.converters['pid'] = PIDConverter
 
     FlaskCLI(app)
     InvenioDB(app)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import, print_function
 from flask import Flask
 
 from invenio_records_rest import InvenioRecordsREST
+from invenio_records_rest.utils import PIDConverter
 
 
 def test_version():
@@ -41,6 +42,7 @@ def test_version():
 def test_init():
     """Test extension initialization."""
     app = Flask('testapp')
+    app.url_map.converters['pid'] = PIDConverter
     ext = InvenioRecordsREST()
     assert 'invenio-records-rest' not in app.extensions
     ext.init_app(app)


### PR DESCRIPTION
@lnielsen can you please review it? We can now use `pid, record = request.view_args['pid_value']` anywhere.

I would like to also remove `@pass_record` decorator.

--
- [ ] release Invenio-Base
- [ ] update Invenio-Deposit and overlay configurations (ping @inveniosoftware/invenio-service-managers)