### PR TITLE
global: addition of models from view args

### DIFF
--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -245,6 +245,10 @@ def pass_record(f):
     def inner(self, pid_value, *args, **kwargs):
         try:
             pid, record = request.view_args['pid_value']
+            # NOTE we must add the record model and PID to the session
+            # since they were obtained in different session scope before
+            # the request context has been pushed.
+            db.session.add_all([record.model, pid])
             return f(self, pid=pid, record=record, *args, **kwargs)
         except SQLAlchemyError:
             abort(500)


### PR DESCRIPTION
* NOTE It is necessary to add models retrieved as view arguments to
  current database session since new SQLAlchemy scoped session is
  created when request context is pushed.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>