### PR TITLE
views: addition of elasticsearch error handler

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,24 +22,12 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-include *.rst
-include *.sh
-include *.txt
-include .dockerignore
-include .editorconfig
-include .tx/config
-include LICENSE
-include babel.ini
-include pytest.ini
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.json
-recursive-include examples *.py
-recursive-include invenio_records_rest *.mo
-recursive-include invenio_records_rest *.po
-recursive-include misc *.py
-recursive-include misc *.rst
-recursive-include tests *.json
-recursive-include tests *.py
+
+[main]
+host = https://www.transifex.com
+
+[invenio-records-rest.messagespot]
+file_filter = invenio_records_rest/translations/<lang>/LC_MESSAGES/messages.po
+source_file = invenio_records_rest/translations/messages.pot
+source_lang = en
+type = PO

--- a/babel.ini
+++ b/babel.ini
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,24 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-include *.rst
-include *.sh
-include *.txt
-include .dockerignore
-include .editorconfig
-include .tx/config
-include LICENSE
-include babel.ini
-include pytest.ini
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.json
-recursive-include examples *.py
-recursive-include invenio_records_rest *.mo
-recursive-include invenio_records_rest *.po
-recursive-include misc *.py
-recursive-include misc *.rst
-recursive-include tests *.json
-recursive-include tests *.py
+# Extraction from Python source files
+
+[python: **.py]
+encoding = utf-8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,14 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
+
+_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/invenio_records_rest/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_records_rest/translations/en/LC_MESSAGES/messages.po
@@ -1,0 +1,32 @@
+# Translations template for invenio-records-rest.
+# Copyright (C) 2016 CERN
+# This file is distributed under the same license as the
+# invenio-records-rest project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: invenio-records-rest 1.0.0a14.dev20160509\n"
+"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"POT-Creation-Date: 2016-06-06 10:49+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.3.4\n"
+
+#: invenio_records_rest/config.py:85
+msgid "Best match"
+msgstr ""
+
+#: invenio_records_rest/config.py:91
+msgid "Most recent"
+msgstr ""
+
+#: invenio_records_rest/views.py:63
+msgid "The syntax of the search query is invalid."
+msgstr ""
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,21 @@ all_files = 1
 
 [bdist_wheel]
 universal = 1
+
+[compile_catalog]
+directory = invenio_records_rest/translations/
+
+[extract_messages]
+copyright_holder = CERN
+msgid_bugs_address = info@invenio-software.org
+mapping-file = babel.ini
+output-file = invenio_records_rest/translations/messages.pot
+add-comments = NOTE
+
+[init_catalog]
+input-file = invenio_records_rest/translations/messages.pot
+output-dir = invenio_records_rest/translations/
+
+[update_catalog]
+input-file = invenio_records_rest/translations/messages.pot
+output-dir = invenio_records_rest/translations/

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ tests_require = [
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.3',
+        'Sphinx>=1.4',
     ],
     'datacite': [
         'datacite>=0.2.1',
@@ -66,10 +66,12 @@ for reqs in extras_require.values():
     extras_require['all'].extend(reqs)
 
 setup_requires = [
+    'Babel>=1.3',
     'pytest-runner>=2.7.0'
 ]
 
 install_requires = [
+    'Flask-BabelEx>=0.9.2',
     'Flask-CLI>=0.2.1',
     'elasticsearch-dsl>=2.0.0',
     'invenio-pidstore>=1.0.0a7',

--- a/tests/test_views_search.py
+++ b/tests/test_views_search.py
@@ -210,3 +210,19 @@ def test_filters(app, indexed_records, search_url):
     with app.test_client() as client:
         res = client.get(search_url, query_string=dict(stars='4'))
         assert_hits_len(res, 2)
+
+
+def test_query_wrong(app, indexed_records, search_url):
+    """Test invalid accept header."""
+    with app.test_client() as client:
+        res = client.get(search_url, query_string={'q': 'test'})
+        assert res.status_code == 200
+
+        res = client.get(search_url, query_string={'q': 'test:a'})
+        assert res.status_code == 200
+
+        res = client.get(search_url, query_string={'q': 'test:'})
+        assert res.status_code == 400
+
+        res = client.get(search_url, query_string={'q': 'test;'})
+        assert res.status_code == 200


### PR DESCRIPTION
* Adds a handler that process the errors coming from ElasticSearch in
  case of a bad request. (closes #84)

* Fixes issue with `Sphinx 1.4`.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>