### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Records-REST.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-records-rest
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_records_rest/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_records_rest/translations/en/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-records-rest 1.0.0a14.dev20160509\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2016-06-06 10:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ directory = invenio_records_rest/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_records_rest/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     keywords='invenio api',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-records-rest',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>