### PR TITLE
views: use endpoint pid_type instead of key for blueprints

### DIFF
--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -82,8 +82,8 @@ def create_blueprint(endpoints):
         url_prefix='',
     )
 
-    for endpoint, options in (endpoints or {}).items():
-        for rule in create_url_rules(endpoint, **options):
+    for options in (endpoints or {}).values():
+        for rule in create_url_rules(options['pid_type'], **options):
             blueprint.add_url_rule(**rule)
 
     # catch record validation errors


### PR DESCRIPTION
* Changes views.py to use pid_type in the endpoint map instead of the key for
  the name of the endpoint. (closes #101)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>