### PR TITLE
utils: new get_default_endpoint_for()

### DIFF
--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -88,8 +88,9 @@ The structure of the dictionary is as follows:
 
 
     RECORDS_REST_ENDPOINTS = {
-        'record-pid-type': {
+        'endpoint-prefix': {
             'create_permission_factory_imp': permission_check_factory(),
+            'default_endpoint_prefix': True,
             'default_media_type': 'application/json',
             'delete_permission_factory_imp': permission_check_factory(),
             'item_route': ''/recods/<pid(record-pid-type):pid_value>'',
@@ -132,6 +133,10 @@ The structure of the dictionary is as follows:
 :param create_permission_factory_imp: Import path to factory that create
     permission object for a given record.
 
+:param default_endpoint_prefix: declare the current endpoint as the default
+    when building endpoints for the defined ``pid_type``. By default the
+    default prefix is defined to be the value of ``pid_type``.
+
 :param default_media_type: Default media type for both records and search.
 
 :param delete_permission_factory_imp: Import path to factory that creates a
@@ -146,10 +151,10 @@ The structure of the dictionary is as follows:
 :param max_result_window: Maximum total number of records retrieved from a
     query.
 
-:param pid_type: It specifies the record pid type. It's used also to build the
-    endpoint name. Required.
+:param pid_type: It specifies the record pid type. Required.
     You can generate an URL to list all records of the given ``pid_type`` by
-    calling ``url_for('invenio_records_rest.{0}_list'.format(pid_type))``.
+    calling ``url_for('invenio_records_rest.{0}_list'.format(
+    current_records_rest.default_endpoint_prefixes[pid_type]))``.
 
 :param pid_fetcher: It identifies the registered fetcher name. Required.
 

--- a/invenio_records_rest/ext.py
+++ b/invenio_records_rest/ext.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import, print_function
 from werkzeug.utils import cached_property
 
 from . import config
-from .utils import load_or_import_from_config
+from .utils import build_default_endpoint_prefixes, load_or_import_from_config
 from .views import create_blueprint
 
 
@@ -74,6 +74,11 @@ class _RecordRESTState(object):
         return load_or_import_from_config(
             'RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY', app=self.app
         )
+
+    @cached_property
+    def default_endpoint_prefixes(self):
+        """Map between pid_type and endpoint_prefix."""
+        return build_default_endpoint_prefixes()
 
     def reset_permission_factories(self):
         """Remove cached permission factories."""

--- a/invenio_records_rest/ext.py
+++ b/invenio_records_rest/ext.py
@@ -78,7 +78,9 @@ class _RecordRESTState(object):
     @cached_property
     def default_endpoint_prefixes(self):
         """Map between pid_type and endpoint_prefix."""
-        return build_default_endpoint_prefixes()
+        return build_default_endpoint_prefixes(
+            self.app.config['RECORDS_REST_ENDPOINTS']
+        )
 
     def reset_permission_factories(self):
         """Remove cached permission factories."""

--- a/invenio_records_rest/links.py
+++ b/invenio_records_rest/links.py
@@ -26,6 +26,8 @@
 
 from flask import url_for
 
+from .proxies import current_records_rest
+
 
 def default_links_factory(pid):
     """Factory for record links generation.
@@ -33,7 +35,8 @@ def default_links_factory(pid):
     :param pid: A Persistent Identifier instance.
     :returns: Dictionary containing a list of useful links for the record.
     """
-    endpoint = '.{0}_item'.format(pid.pid_type)
+    endpoint = '.{0}_item'.format(
+        current_records_rest.default_endpoint_prefixes[pid.pid_type])
     links = dict(self=url_for(endpoint, pid_value=pid.pid_value,
                  _external=True))
     return links

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -130,7 +130,7 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
                      default_media_type=None,
                      max_result_window=None, use_options_view=True,
                      search_factory_imp=None, links_factory_imp=None,
-                     suggesters=None):
+                     suggesters=None, default_endpoint_prefix=None):
     """Create Werkzeug URL rules.
 
     :param endpoint: Name of endpoint.
@@ -148,6 +148,7 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
         update permission object for a given record.
     :param delete_permission_factory_imp: Import path to factory that creates a
         delete permission object for a given record.
+    :param default_endpoint_prefix: ignored.
     :param record_class: A record API class or importable string.
     :param record_serializers: Serializers used for records.
     :param record_loaders: It contains the list of record deserializers for
@@ -452,7 +453,8 @@ class RecordsListResource(ContentNegotiatedMethodView):
             size=size,
             _external=True,
         )
-        endpoint = '.{0}_list'.format(self.pid_type)
+        endpoint = '.{0}_list'.format(
+            current_records_rest.default_endpoint_prefixes[self.pid_type])
         links = dict(self=url_for(endpoint, page=page, **urlkwargs))
         if page > 1:
             links['prev'] = url_for(endpoint, page=page - 1, **urlkwargs)
@@ -515,7 +517,8 @@ class RecordsListResource(ContentNegotiatedMethodView):
             pid, record, 201, links_factory=self.item_links_factory)
 
         # Add location headers
-        endpoint = '.{0}_item'.format(pid.pid_type)
+        endpoint = '.{0}_item'.format(
+            current_records_rest.default_endpoint_prefixes[pid.pid_type])
         location = url_for(endpoint, pid_value=pid.pid_value, _external=True)
         response.headers.extend(dict(location=location))
         return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,21 @@ def app(request, search_class):
 
     This will parameterize the default 'recid' endpoint in
     RECORDS_REST_ENDPOINTS.
+
+    Alternatively:
+
+    .. code-block:: python
+
+    @pytest.mark.parametrize('app', [dict(
+        records_rest_endpoints=dict(
+            recid=dict(
+                search_class='conftest:TestSearch',
+            )
+        )
+    def test_mytest(app, db, es):
+        # ...
+
+    This will fully parameterize RECORDS_REST_ENDPOINTS.
     """
     instance_path = tempfile.mkdtemp()
     app = Flask('testapp', instance_path=instance_path)
@@ -156,6 +171,15 @@ def app(request, search_class):
         if 'endpoint' in request.param:
             app.config['RECORDS_REST_ENDPOINTS']['recid'].update(
                 request.param['endpoint'])
+        if 'records_rest_endpoints' in request.param:
+            original_endpoint = app.config['RECORDS_REST_ENDPOINTS']['recid']
+            del app.config['RECORDS_REST_ENDPOINTS']['recid']
+            for new_endpoint_prefix, new_endpoint_value in \
+                    request.param['records_rest_endpoints'].items():
+                new_endpoint = dict(original_endpoint)
+                new_endpoint.update(new_endpoint_value)
+                app.config['RECORDS_REST_ENDPOINTS'][new_endpoint_prefix] = \
+                    new_endpoint
 
     app.url_map.converters['pid'] = PIDConverter
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
+import copy
 import json
 import os
 import shutil
@@ -133,7 +134,7 @@ def app(request, search_class):
     app.config.update(
         INDEXER_DEFAULT_DOC_TYPE='testrecord',
         INDEXER_DEFAULT_INDEX=search_class.Meta.index,
-        RECORDS_REST_ENDPOINTS=config.RECORDS_REST_ENDPOINTS,
+        RECORDS_REST_ENDPOINTS=copy.deepcopy(config.RECORDS_REST_ENDPOINTS),
         RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY=None,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,16 +30,17 @@ from __future__ import absolute_import, print_function
 import pytest
 
 from invenio_records_rest.proxies import current_records_rest
-from invenio_records_rest.utils import get_default_endpoint_for
+from invenio_records_rest.utils import build_default_endpoint_prefixes
 
 
 @pytest.mark.parametrize('app', [dict(
-        records_rest_endpoints=dict(
-            recid=dict(
-                pid_type='recid',
-                default_endpoint_prefix=False,
-            )
-        ))], indirect=['app'])
+    records_rest_endpoints=dict(
+        recid=dict(
+            pid_type='recid',
+            default_endpoint_prefix=False,
+        )
+    ),
+)], indirect=['app'])
 def test_build_default_endpoint_prefixes_simple(app):
     with app.test_client():
         assert current_records_rest.default_endpoint_prefixes['recid'] == \
@@ -47,12 +48,13 @@ def test_build_default_endpoint_prefixes_simple(app):
 
 
 @pytest.mark.parametrize('app', [dict(
-        records_rest_endpoints=dict(
-            recid=dict(
-                pid_type='recid',
-                default_endpoint_prefix=True,
-            )
-        ))], indirect=['app'])
+    records_rest_endpoints=dict(
+        recid=dict(
+            pid_type='recid',
+            default_endpoint_prefix=True,
+        )
+    ),
+)], indirect=['app'])
 def test_build_default_endpoint_prefixes_simple_with_default(app):
     with app.test_client():
         assert current_records_rest.default_endpoint_prefixes['recid'] == \
@@ -60,16 +62,17 @@ def test_build_default_endpoint_prefixes_simple_with_default(app):
 
 
 @pytest.mark.parametrize('app', [dict(
-        records_rest_endpoints=dict(
-            recid=dict(
-                pid_type='recid',
-                default_endpoint_prefix=False,
-            ),
-            recid2=dict(
-                pid_type='recid',
-                default_endpoint_prefix=False,
-            )
-        ))], indirect=['app'])
+    records_rest_endpoints=dict(
+        recid=dict(
+            pid_type='recid',
+            default_endpoint_prefix=False,
+        ),
+        recid2=dict(
+            pid_type='recid',
+            default_endpoint_prefix=False,
+        )
+    ),
+)], indirect=['app'])
 def test_build_default_endpoint_prefixes_two_simple_endpoints(app):
     with app.test_client():
         assert current_records_rest.default_endpoint_prefixes['recid'] == \
@@ -77,16 +80,17 @@ def test_build_default_endpoint_prefixes_two_simple_endpoints(app):
 
 
 @pytest.mark.parametrize('app', [dict(
-        records_rest_endpoints=dict(
-            recid=dict(
-                pid_type='recid',
-                default_endpoint_prefix=True,
-            ),
-            recid2=dict(
-                pid_type='recid',
-                default_endpoint_prefix=False,
-            )
-        ))], indirect=['app'])
+    records_rest_endpoints=dict(
+        recid=dict(
+            pid_type='recid',
+            default_endpoint_prefix=True,
+        ),
+        recid2=dict(
+            pid_type='recid',
+            default_endpoint_prefix=False,
+        )
+    ),
+)], indirect=['app'])
 def test_build_default_endpoint_prefixes_redundant_default(app):
     with app.test_client():
         assert current_records_rest.default_endpoint_prefixes['recid'] == \
@@ -94,16 +98,17 @@ def test_build_default_endpoint_prefixes_redundant_default(app):
 
 
 @pytest.mark.parametrize('app', [dict(
-        records_rest_endpoints=dict(
-            recid=dict(
-                pid_type='recid',
-                default_endpoint_prefix=False,
-            ),
-            recid2=dict(
-                pid_type='recid',
-                default_endpoint_prefix=True,
-            )
-        ))], indirect=['app'])
+    records_rest_endpoints=dict(
+        recid=dict(
+            pid_type='recid',
+            default_endpoint_prefix=False,
+        ),
+        recid2=dict(
+            pid_type='recid',
+            default_endpoint_prefix=True,
+        )
+    ),
+)], indirect=['app'])
 def test_build_default_endpoint_prefixes_two_endpoints_with_default(app):
     with app.test_client():
         assert current_records_rest.default_endpoint_prefixes['recid'] == \
@@ -112,7 +117,7 @@ def test_build_default_endpoint_prefixes_two_endpoints_with_default(app):
 
 def test_get_default_endpoint_for_inconsistent(app):
     with pytest.raises(ValueError) as excinfo:
-        get_default_endpoint_for('recid', {
+        build_default_endpoint_prefixes({
             'recid1': {
                 'pid_type': 'recid',
                 'default_endpoint_prefix': True,
@@ -120,25 +125,17 @@ def test_get_default_endpoint_for_inconsistent(app):
             'recid2': {
                 'pid_type': 'recid',
                 'default_endpoint_prefix': True,
-            }})
+            },
+        })
     assert 'More than one' in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
-        get_default_endpoint_for('recid', {
+        build_default_endpoint_prefixes({
             'recid1': {
                 'pid_type': 'recid',
             },
             'recid2': {
                 'pid_type': 'recid',
-            }})
-    assert 'No endpoint-prefix' in str(excinfo.value)
-
-    with pytest.raises(ValueError) as excinfo:
-        get_default_endpoint_for('foo', {
-            'recid1': {
-                'pid_type': 'recid',
             },
-            'recid2': {
-                'pid_type': 'recid',
-            }})
+        })
     assert 'No endpoint-prefix' in str(excinfo.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Utils tests."""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from invenio_records_rest.proxies import current_records_rest
+from invenio_records_rest.utils import get_default_endpoint_for
+
+
+@pytest.mark.parametrize('app', [dict(
+        records_rest_endpoints=dict(
+            recid=dict(
+                pid_type='recid',
+                default_endpoint_prefix=False,
+            )
+        ))], indirect=['app'])
+def test_build_default_endpoint_prefixes_simple(app):
+    with app.test_client():
+        assert current_records_rest.default_endpoint_prefixes['recid'] == \
+            'recid'
+
+
+@pytest.mark.parametrize('app', [dict(
+        records_rest_endpoints=dict(
+            recid=dict(
+                pid_type='recid',
+                default_endpoint_prefix=True,
+            )
+        ))], indirect=['app'])
+def test_build_default_endpoint_prefixes_simple_with_default(app):
+    with app.test_client():
+        assert current_records_rest.default_endpoint_prefixes['recid'] == \
+            'recid'
+
+
+@pytest.mark.parametrize('app', [dict(
+        records_rest_endpoints=dict(
+            recid=dict(
+                pid_type='recid',
+                default_endpoint_prefix=False,
+            ),
+            recid2=dict(
+                pid_type='recid',
+                default_endpoint_prefix=False,
+            )
+        ))], indirect=['app'])
+def test_build_default_endpoint_prefixes_two_simple_endpoints(app):
+    with app.test_client():
+        assert current_records_rest.default_endpoint_prefixes['recid'] == \
+            'recid'
+
+
+@pytest.mark.parametrize('app', [dict(
+        records_rest_endpoints=dict(
+            recid=dict(
+                pid_type='recid',
+                default_endpoint_prefix=True,
+            ),
+            recid2=dict(
+                pid_type='recid',
+                default_endpoint_prefix=False,
+            )
+        ))], indirect=['app'])
+def test_build_default_endpoint_prefixes_redundant_default(app):
+    with app.test_client():
+        assert current_records_rest.default_endpoint_prefixes['recid'] == \
+            'recid'
+
+
+@pytest.mark.parametrize('app', [dict(
+        records_rest_endpoints=dict(
+            recid=dict(
+                pid_type='recid',
+                default_endpoint_prefix=False,
+            ),
+            recid2=dict(
+                pid_type='recid',
+                default_endpoint_prefix=True,
+            )
+        ))], indirect=['app'])
+def test_build_default_endpoint_prefixes_two_endpoints_with_default(app):
+    with app.test_client():
+        assert current_records_rest.default_endpoint_prefixes['recid'] == \
+            'recid2'
+
+
+def test_get_default_endpoint_for_inconsistent(app):
+    with pytest.raises(ValueError) as excinfo:
+        get_default_endpoint_for('recid', {
+            'recid1': {
+                'pid_type': 'recid',
+                'default_endpoint_prefix': True,
+            },
+            'recid2': {
+                'pid_type': 'recid',
+                'default_endpoint_prefix': True,
+            }})
+    assert 'More than one' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        get_default_endpoint_for('recid', {
+            'recid1': {
+                'pid_type': 'recid',
+            },
+            'recid2': {
+                'pid_type': 'recid',
+            }})
+    assert 'No endpoint-prefix' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        get_default_endpoint_for('foo', {
+            'recid1': {
+                'pid_type': 'recid',
+            },
+            'recid2': {
+                'pid_type': 'recid',
+            }})
+    assert 'No endpoint-prefix' in str(excinfo.value)


### PR DESCRIPTION
* NEW Introduces new RECORDS_REST_PID_TYPE_DEFAULT_ENDPOINT config
  variable, needed in order to know which default endpoint corresponds
  to which pid_type when building URIs. (closes #101)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>

(supersedes #109)