### PR TITLE
global: Datacite v4.0 support.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,4 +32,5 @@ REST API for invenio-records.
 - Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 - Nicolas Harraudeau <nicolas.harraudeau@cern.ch>
 - Orestis Melkonian <melkon.or@gmail.com>
+- Rémi Ducceschi <remi.ducceschi@gmail.com>
 - Tibor Simko <tibor.simko@cern.ch>

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extras_require = {
         'Sphinx>=1.4.2',
     ],
     'datacite': [
-        'datacite>=0.2.1',
+        'datacite>=0.3.0',
     ],
     'dublincore': [
         'dcxml>=0.1.0',


### PR DESCRIPTION
Added wrapper class for the new Datacite v4.0 support in Datacite module (see https://github.com/inveniosoftware/datacite/pull/18)

INCOMPATIBLE: the constructor of `OAIDataCiteSerializer` now takes a "serializer" parameter instead of a "v31".

Signed-off-by: Rémi Ducceschi <remi.ducceschi@gmail.com>