### PR TITLE
serializers: citeproc serializer

### DIFF
--- a/invenio_records_rest/serializers/citeproc.py
+++ b/invenio_records_rest/serializers/citeproc.py
@@ -124,9 +124,10 @@ class CiteprocSerializer(object):
             return BibTeX(data)
 
     def _clean_result(self, text):
-        """Remove double spaces and punctuation."""
+        """Remove double spaces, punctuation and escapes apostrophes."""
         text = re.sub('\s\s+', ' ', text)
         text = re.sub('\.\.+', '.', text)
+        text = text.replace("'", "\\'")
         return text
 
     def serialize(self, pid, record, links_factory=None, **kwargs):


### PR DESCRIPTION
* Escapes apostrophe character in the final result returned.

Signed-off-by: satwikkansal <satwikkansal@gmail.com>

FIxes https://github.com/zenodo/zenodo/issues/959

![screenshot from 2017-03-03 19-30-14](https://cloud.githubusercontent.com/assets/10217535/23554094/a39e5f22-0049-11e7-8093-79536a96189b.png)
