### PR TITLE
global: refactor serializers

### DIFF
--- a/invenio_records_rest/_compat.py
+++ b/invenio_records_rest/_compat.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Python 2/3 compatibility helpers."""
+
+try:  # Python 3 way of inspecting functions
+    from inspect import signature, Parameter
+
+    def wrap_links_factory(links_factory):
+        """Test if the links_factory function accepts kwargs."""
+        sign = signature(links_factory)
+        kwargs_param = [p for p in sign.parameters.values()
+                        if p.kind == Parameter.VAR_KEYWORD]
+        return len(kwargs_param) == 0
+except ImportError:  # Python 2 way of inspecting functions
+    from inspect import getargspec
+
+    def wrap_links_factory(links_factory):
+        """Test if the links_factory function accepts kwargs."""
+        spec = getargspec(links_factory)
+        return spec.keywords is None

--- a/invenio_records_rest/links.py
+++ b/invenio_records_rest/links.py
@@ -33,7 +33,7 @@ from flask import request, url_for
 from .proxies import current_records_rest
 
 
-def default_links_factory(pid):
+def default_links_factory(pid, record=None, **kwargs):
     """Factory for record links generation.
 
     :param pid: A Persistent Identifier instance.
@@ -53,7 +53,7 @@ def default_links_factory_with_additional(additional_links):
            returned object.
     :returns: A link generation factory.
     """
-    def factory(pid):
+    def factory(pid, **kwargs):
         links = default_links_factory(pid)
         for link in additional_links:
             links[link] = additional_links[link].format(pid=pid,

--- a/invenio_records_rest/serializers/base.py
+++ b/invenio_records_rest/serializers/base.py
@@ -31,22 +31,137 @@ import copy
 import pytz
 
 
-class PreprocessorMixin(object):
+class SerializerMixinInterface(object):
+    """Mixin serializing records.
+
+    A record serializer should inherit subclasses of
+    - SerializerMixinInterface
+    - TransformerMixinInterface
+    - PreprocessorMixinInterface
+
+    This class forwards its input to the transformer mixin and serializes its
+    result.
+    """
+
+    def serialize(self, pid, record, links_factory=None, **kwargs):
+        """Serialize a single record and persistent identifier.
+
+        This method should delegate the record transformation to the
+        transformer mixin's transform_record method.
+
+        :param pid: Persistent identifier instance.
+        :param record: Record instance.
+        :param links_factory: Factory function for record links.
+        """
+        raise NotImplementedError()
+
+    def serialize_search(self, pid_fetcher, search_result, links=None,
+                         item_links_factory=None, **kwargs):
+        """Serialize a search result.
+
+        This method should delegate each record search hit transformation
+        to the transformer mixin's transform_search_hit method.
+
+        :param pid_fetcher: Persistent identifier fetcher.
+        :param search_result: Elasticsearch search result.
+        :param links: Dictionary of links to add to response.
+        :param item_links_factory: Factory function for record links.
+        """
+        raise NotImplementedError()
+
+    def serialize_oaipmh(self, pid, record):
+        """Serialize a single record for OAI-PMH.
+
+        :param pid: The :class:`invenio_pidstore.models.PersistentIdentifier`
+            instance.
+        :param record: The :class:`invenio_records.api.Record` instance.
+        :returns: The object serialized.
+        """
+        raise NotImplementedError()
+
+
+class TransformerMixinInterface(object):
+    """Mixin transforming records during serialization.
+
+    This class should be mixed with a PreprocessorMixinInterface subclass and
+    a SerializerMixinInterface subclass.
+
+    This class transforms the dictionary returned by the preprocessor.
+    """
+
+    def transform_record(self, pid, record, links_factory=None, **kwargs):
+        """Transform record into an intermediate representation.
+
+        This method should delegate the record preprocessing to the
+        preprocessor mixin's preprocess_record method.
+
+        :param pid: Persistent identifier instance.
+        :param record: Record instance.
+        :param links_factory: Factory function for record links.
+        """
+        raise NotImplementedError()
+
+    def transform_search_hit(self, pid, record_hit, links_factory=None,
+                             **kwargs):
+        """Transform search result hit into an intermediate representation.
+
+        This method should delegate the record preprocessing to the
+        preprocessor mixin's preprocess_search_hit method.
+
+        :param pid: Persistent identifier instance.
+        :param pid: Persistent identifier instance.
+        :param record_hit: Record metadata retrieved via search.
+        :param links_factory: Factory function for record links.
+        """
+        raise NotImplementedError()
+
+
+class PreprocessorMixinInterface(object):
+    """Mixin preprocessing records during serialization.
+
+    This class should be mixed with a TransformerMixinInteface subclass and
+    a SerializerMixinInterface subclass.
+
+    This class builds a dictionary which is then transformed and serialized.
+    """
+
+    def preprocess_record(self, pid, record, links_factory=None, **kwargs):
+        """Prepare a record and persistent identifier for serialization.
+
+        :param pid: Persistent identifier instance.
+        :param record: Record instance.
+        :param links_factory: Factory function for record links.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
+        """Prepare a record hit from Elasticsearch for serialization.
+
+        :param pid: Persistent identifier instance.
+        :param record_hit: Record metadata retrieved via search.
+        :param links_factory: Factory function for record links.
+        """
+        raise NotImplementedError()
+
+
+class PreprocessorMixin(PreprocessorMixinInterface):
     """Base class for serializers."""
 
-    def __init__(self, replace_refs=False):
-        """."""
+    def __init__(self, replace_refs=False, **kwargs):
+        """Constructor."""
+        super(PreprocessorMixin, self).__init__(**kwargs)
         self.replace_refs = replace_refs
 
-    def preprocess_record(self, pid, record, links_factory=None):
+    def preprocess_record(self, pid, record, links_factory=None, **kwargs):
         """Prepare a record and persistent identifier for serialization."""
-        links_factory = links_factory or (lambda x: dict())
+        links_factory = links_factory or (lambda x, record=None, **k: dict())
         metadata = copy.deepcopy(record.replace_refs()) if self.replace_refs \
             else record.dumps()
         return dict(
             pid=pid,
             metadata=metadata,
-            links=links_factory(pid),
+            links=links_factory(pid, record=record, **kwargs),
             revision=record.revision_id,
             created=(pytz.utc.localize(record.created).isoformat()
                      if record.created else None),
@@ -55,13 +170,13 @@ class PreprocessorMixin(object):
         )
 
     @staticmethod
-    def preprocess_search_hit(pid, record_hit, links_factory=None):
+    def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
         """Prepare a record hit from Elasticsearch for serialization."""
-        links_factory = links_factory or (lambda x: dict())
+        links_factory = links_factory or (lambda x, **k: dict())
         record = dict(
             pid=pid,
             metadata=record_hit['_source'],
-            links=links_factory(pid),
+            links=links_factory(pid, record_hit=record_hit, **kwargs),
             revision=record_hit['_version'],
             created=None,
             updated=None,

--- a/invenio_records_rest/serializers/datacite.py
+++ b/invenio_records_rest/serializers/datacite.py
@@ -31,10 +31,11 @@ from invenio_records.api import Record
 from lxml import etree
 from lxml.builder import E
 
-from .marshmallow import MarshmallowSerializer
+from .base import PreprocessorMixin
+from .marshmallow import MarshmallowMixin
 
 
-class BaseDataCiteSerializer(MarshmallowSerializer):
+class BaseDataCiteSerializer(MarshmallowMixin, PreprocessorMixin):
     """Marshmallow based DataCite serializer for records.
 
     Note: This serializer is not suitable for serializing large number of

--- a/invenio_records_rest/serializers/dc.py
+++ b/invenio_records_rest/serializers/dc.py
@@ -29,10 +29,12 @@ from __future__ import absolute_import, print_function
 from dcxml import simpledc
 from invenio_records.api import Record
 
-from .marshmallow import MarshmallowSerializer
+from .base import PreprocessorMixin, SerializerMixinInterface
+from .marshmallow import MarshmallowMixin
 
 
-class DublinCoreSerializer(MarshmallowSerializer):
+class DublinCoreSerializer(SerializerMixinInterface, MarshmallowMixin,
+                           PreprocessorMixin):
     """Marshmallow based DublinCore serializer for records.
 
     Note: This serializer is not suitable for serializing large number of

--- a/invenio_records_rest/serializers/jsonld.py
+++ b/invenio_records_rest/serializers/jsonld.py
@@ -29,31 +29,20 @@ from __future__ import absolute_import, print_function
 import copy
 
 from flask import request
-from marshmallow import Schema, fields
-from marshmallow.decorators import post_dump
 from pyld import jsonld
 
+from .base import TransformerMixinInterface
 from .json import JSONSerializer
 
 
-class RecordMetadataOnlySchema(Schema):
-    """Schema which extracts the metadata only."""
-
-    @post_dump
-    def post_dump(self, obj):
-        """Get metadata only from the record."""
-        return obj.get('metadata', {})
-
-
-class JSONLDSerializer(JSONSerializer):
+class JSONLDTransformerMixin(TransformerMixinInterface):
     """JSON-LD serializer for records.
 
     Note: This serializer is not suitable for serializing large number of
     records.
     """
 
-    def __init__(self, context, schema_class=RecordMetadataOnlySchema,
-                 expanded=True, replace_refs=False):
+    def __init__(self, context, expanded=True, **kwargs):
         """Initialize record.
 
         :param context: JSON-LD context.
@@ -63,9 +52,7 @@ class JSONLDSerializer(JSONSerializer):
         """
         self.context = context
         self._expanded = expanded
-        super(JSONLDSerializer, self).__init__(
-            schema_class=schema_class, replace_refs=replace_refs
-        )
+        super(JSONLDTransformerMixin, self).__init__(**kwargs)
 
     @property
     def expanded(self):
@@ -78,12 +65,31 @@ class JSONLDSerializer(JSONSerializer):
                 return False
         return self._expanded
 
-    def dump(self, obj):
+    def transform_jsonld(self, obj):
         """Compact JSON according to context."""
-        rec = copy.deepcopy(super(JSONLDSerializer, self).dump(obj))
+        rec = copy.deepcopy(obj)
         rec.update(self.context)
         compacted = jsonld.compact(rec, self.context)
         if not self.expanded:
             return compacted
         else:
             return jsonld.expand(compacted)[0]
+
+    def transform_record(self, pid, record, links_factory=None, **kwargs):
+        """Transform record into an intermediate representation."""
+        result = super(JSONLDTransformerMixin, self).transform_record(
+            pid, record, links_factory, **kwargs
+        )
+        return self.transform_jsonld(result)
+
+    def transform_search_hit(self, pid, record_hit, links_factory=None,
+                             **kwargs):
+        """Transform search result hit into an intermediate representation."""
+        result = super(JSONLDTransformerMixin, self).transform_search_hit(
+            pid, record_hit, links_factory, **kwargs
+        )
+        return self.transform_jsonld(result)
+
+
+class JSONLDSerializer(JSONLDTransformerMixin, JSONSerializer):
+    """JSON-LD serializer for records supporting Marshmallow schemas."""

--- a/invenio_records_rest/serializers/marshmallow.py
+++ b/invenio_records_rest/serializers/marshmallow.py
@@ -26,28 +26,35 @@
 
 from __future__ import absolute_import, print_function
 
-from .base import PreprocessorMixin
+from .base import TransformerMixinInterface
+from .schemas.json import RecordSchemaJSONV1
 
 
-class MarshmallowSerializer(PreprocessorMixin):
+class MarshmallowMixin(TransformerMixinInterface):
     """Base class for marshmallow serializers."""
 
-    def __init__(self, schema_class=None, replace_refs=False):
+    def __init__(self, schema_class=RecordSchemaJSONV1, **kwargs):
         """Initialize record."""
         self.schema_class = schema_class
-        super(MarshmallowSerializer, self).__init__(
-            replace_refs=replace_refs)
+        super(MarshmallowMixin, self).__init__(**kwargs)
 
-    def dump(self, obj):
+    def dump(self, obj, context=None):
         """Serialize object with schema."""
-        return self.schema_class().dump(obj).data if self.schema_class else obj
+        return self.schema_class(context=context).dump(obj).data
 
-    def transform_record(self, pid, record, links_factory=None):
+    def transform_record(self, pid, record, links_factory=None, **kwargs):
         """Transform record into an intermediate representation."""
+        context = kwargs.get('marshmallow_context', {})
         return self.dump(self.preprocess_record(pid, record,
-                         links_factory=links_factory))
+                         links_factory=links_factory, **kwargs), context)
 
-    def transform_search_hit(self, pid, record_hit, links_factory=None):
+    def transform_search_hit(self, pid, record_hit, links_factory=None,
+                             **kwargs):
         """Transform search result hit into an intermediate representation."""
+        context = kwargs.get('marshmallow_context', {})
         return self.dump(self.preprocess_search_hit(pid, record_hit,
-                         links_factory=links_factory))
+                         links_factory=links_factory, **kwargs), context)
+
+
+MarshmallowSerializer = MarshmallowMixin
+"""Marshmallow Serializer, only for backward compatibility."""

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -48,6 +48,7 @@ from jsonpatch import JsonPatchException, JsonPointerException
 from jsonschema.exceptions import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 
+from ._compat import wrap_links_factory
 from .errors import InvalidDataRESTError, InvalidQueryRESTError, \
     JSONSchemaValidationError, MaxResultWindowRESTError, \
     PatchJSONFailureRESTError, PIDResolveRESTError, \
@@ -236,6 +237,13 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
     links_factory = obj_or_import_string(
         links_factory_imp, default=default_links_factory
     )
+    # For backward compatibility. Previous signature was links_factory(pid).
+    if wrap_links_factory(links_factory):
+        orig_links_factory = links_factory
+
+        def links_factory(pid, record=None, **kwargs):
+            return orig_links_factory(pid)
+
     record_class = obj_or_import_string(
         record_class, default=Record
     )

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -27,9 +27,14 @@
 
 from __future__ import absolute_import, print_function
 
-from helpers import create_record
+import copy
 
+import pytest
+from helpers import create_record, get_json, record_url
+
+from invenio_records_rest.config import RECORDS_REST_ENDPOINTS
 from invenio_records_rest.links import default_links_factory_with_additional
+from invenio_records_rest.views import create_blueprint
 
 
 def test_default_links_factory_with_additional(app, db):
@@ -40,3 +45,31 @@ def test_default_links_factory_with_additional(app, db):
             dict(test_link='{scheme}://{host}/{pid.pid_value}'))
         links = link_factory(pid)
         assert links['test_link'] == 'http://localhost:5000/1'
+
+
+# Create a configuration with an old link factory. Used in the next test.
+config = copy.deepcopy(RECORDS_REST_ENDPOINTS)
+config['recid']['links_factory_imp'] = \
+    lambda pid: {'test_link': 'http://old_links_factory.com'}
+
+
+@pytest.mark.parametrize('app', [dict(
+    # Provide the configuration with the old links_factory
+    records_rest_endpoints=config,
+)], indirect=['app'])
+def test_old_signature_backward_compatibility(app, test_records):
+    """Check that the old Links_factory signature is still supported.
+
+    This old signature was links_factory(pid), without "record" and "**kwargs"
+    parameters.
+    """
+    # blueprint = create_blueprint(config)
+    with app.test_client() as client:
+        pid, record = test_records[0]
+
+        res = client.get(record_url(pid))
+        assert res.status_code == 200
+
+        # Check metadata
+        data = get_json(res)
+        assert data['links']['test_link'] == 'http://old_links_factory.com'

--- a/tests/test_serializer_marshmallow.py
+++ b/tests/test_serializer_marshmallow.py
@@ -30,30 +30,52 @@ from invenio_pidstore.models import PersistentIdentifier
 from invenio_records import Record
 from marshmallow import Schema, fields
 
-from invenio_records_rest.serializers.marshmallow import MarshmallowSerializer
+from invenio_records_rest.serializers.base import PreprocessorMixin
+from invenio_records_rest.serializers.marshmallow import MarshmallowMixin
+
+
+class SimpleMarshmallowSerializer(MarshmallowMixin, PreprocessorMixin):
+    """Simple Marshmallow serializer."""
+
+
+class TestSchema(Schema):
+    title = fields.Str(attribute='metadata.title')
+    author = fields.Function(lambda metadata, context: context['author'])
 
 
 def test_transform_record():
     """Test marshmallow serializer."""
-    class TestSchema(Schema):
-        title = fields.Str(attribute='metadata.title')
-
-    serializer = MarshmallowSerializer(TestSchema)
+    serializer = SimpleMarshmallowSerializer(TestSchema)
     data = serializer.transform_record(
         PersistentIdentifier(pid_type='recid', pid_value='1'),
-        Record({'title': 'test'})
+        Record({'title': 'test'}),
+        marshmallow_context=dict(author='test2')
     )
-    assert data == dict(title='test')
+    assert data == dict(title='test', author='test2')
 
 
 def test_transform_search_hit():
     """Test marshmallow serializer."""
-    class TestSchema(Schema):
-        title = fields.Str(attribute='metadata.title')
+    serializer = SimpleMarshmallowSerializer(TestSchema)
+    data = serializer.transform_record(
+        PersistentIdentifier(pid_type='recid', pid_value='1'),
+        Record({'title': 'test'}),
+        marshmallow_context=dict(author='test2')
+    )
+    assert data == dict(title='test', author='test2')
 
-    serializer = MarshmallowSerializer(TestSchema)
+
+def test_transform_record_default_schema():
+    """Test marshmallow serializer without providing a schema."""
+    serializer = SimpleMarshmallowSerializer()
     data = serializer.transform_record(
         PersistentIdentifier(pid_type='recid', pid_value='1'),
         Record({'title': 'test'})
     )
-    assert data == dict(title='test')
+    assert data == {
+        'id': 1,
+        'created': None,
+        'links': {},
+        'metadata': {'title': 'test'},
+        'updated': None
+    }


### PR DESCRIPTION
* NEW Adds support for marshmallow context in MarshmallowMixin.
  (closes #110)

* BETTER Refactors the serializers in order to make them work
  better as mixins.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>