### PR TITLE
global: indexing after actions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -337,6 +337,9 @@ intersphinx_mapping = {
     'invenio-access': (
         'https://invenio-access.readthedocs.io/en/latest/', None
     ),
+    'invenio-indexer': (
+        'https://invenio-indexer.readthedocs.io/en/latest/', None
+    ),
     'invenio-search': (
         'https://invenio-search.readthedocs.io/en/latest/', None
     ),

--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 from flask import request
+from invenio_indexer.api import RecordIndexer
 from invenio_search import RecordsSearch
 
 from .facets import terms_filter
@@ -43,6 +44,7 @@ RECORDS_REST_ENDPOINTS = dict(
         pid_minter='recid',
         pid_fetcher='recid',
         search_class=RecordsSearch,
+        indexer_class=RecordIndexer,
         search_index=None,
         search_type=None,
         record_serializers={

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ install_requires = [
     'invenio-pidstore>=1.0.0b1',
     'invenio-records>=1.0.0b1',
     'invenio-rest>=1.0.0b2',
+    'invenio-indexer>=1.0.0a10',
     'invenio-search>=1.0.0a11',
     'marshmallow>=2.5.0',
     'python-dateutil>=2.4.2',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ class IndexFlusher(object):
 
     def flush_and_wait(self):
         """Flush index and wait until operation is fully done."""
-        current_search.flush_and_refresh(search_class.Meta.index)
+        current_search.flush_and_refresh(self.search_class.Meta.index)
 
 
 @pytest.yield_fixture(scope='session')
@@ -188,6 +188,7 @@ def app(request, search_class):
     InvenioDB(app)
     InvenioREST(app)
     InvenioRecords(app)
+    InvenioIndexer(app)
     InvenioPIDStore(app)
     search = InvenioSearch(app)
     search.register_mappings(search_class.Meta.index, 'mappings')

--- a/tests/test_views_item_delete.py
+++ b/tests/test_views_item_delete.py
@@ -33,11 +33,11 @@ from mock import patch
 from sqlalchemy.exc import SQLAlchemyError
 
 
-def test_valid_delete(app, test_records):
+def test_valid_delete(app, indexed_records):
     """Test VALID record delete request (DELETE .../records/<record_id>)."""
     # Test with and without headers
     for i, headers in enumerate([[], [('Accept', 'video/mp4')]]):
-        pid, record = test_records[i]
+        pid, record = indexed_records[i]
         with app.test_client() as client:
             res = client.delete(record_url(pid), headers=headers)
             assert res.status_code == 204
@@ -46,9 +46,9 @@ def test_valid_delete(app, test_records):
             assert res.status_code == 410
 
 
-def test_delete_deleted(app, test_records):
+def test_delete_deleted(app, indexed_records):
     """Test deleting a perviously deleted record."""
-    pid, record = test_records[0]
+    pid, record = indexed_records[0]
 
     with app.test_client() as client:
         res = client.delete(record_url(pid))
@@ -61,7 +61,7 @@ def test_delete_deleted(app, test_records):
         assert data['status'] == 410
 
 
-def test_delete_notfound(app, test_records):
+def test_delete_notfound(app, indexed_records):
     """Test INVALID record delete request (DELETE .../records/<record_id>)."""
     with app.test_client() as client:
         # Check that GET with non existing id will return 404
@@ -70,9 +70,9 @@ def test_delete_notfound(app, test_records):
         assert res.status_code == 404
 
 
-def test_delete_with_sqldatabase_error(app, test_records):
+def test_delete_with_sqldatabase_error(app, indexed_records):
     """Test VALID record delete request (GET .../records/<record_id>)."""
-    pid, record = test_records[0]
+    pid, record = indexed_records[0]
 
     with app.test_client() as client:
         def raise_error():

--- a/tests/test_views_item_patch.py
+++ b/tests/test_views_item_patch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,13 +30,15 @@ import json
 
 import mock
 import pytest
-from helpers import _mock_validate_fail, get_json, record_url
+from conftest import IndexFlusher
+from helpers import _mock_validate_fail, assert_hits_len, get_json, record_url
 
 
 @pytest.mark.parametrize('content_type', [
     'application/json-patch+json', 'application/json-patch+json;charset=utf-8'
 ])
-def test_valid_patch(app, test_records, test_patch, content_type):
+def test_valid_patch(app, es, test_records, test_patch, content_type,
+                     search_url, search_class):
     """Test VALID record patch request (PATCH .../records/<record_id>)."""
     HEADERS = [
         ('Accept', 'application/json'),
@@ -57,34 +59,48 @@ def test_valid_patch(app, test_records, test_patch, content_type):
         assert res.status_code == 200
 
         # Check that year changed.
-        assert previous_year != get_json(client.get(url))['metadata']['year']
+        new_year = get_json(client.get(url))['metadata']['year']
+        assert previous_year != new_year
+        IndexFlusher(search_class).flush_and_wait()
+        res = client.get(search_url, query_string={'year': new_year})
+        assert_hits_len(res, 1)
 
 
 @pytest.mark.parametrize('content_type', [
     'application/json-patch+json', 'application/json-patch+json;charset=utf-8'
 ])
-def test_patch_deleted(app, test_records, test_patch, content_type):
+def test_patch_deleted(app, db, es, test_data, test_patch, content_type,
+                       search_url, search_class):
     """Test patching deleted record."""
     HEADERS = [
         ('Accept', 'application/json'),
         ('Content-Type', content_type)
     ]
-    pid, record = test_records[0]
 
     with app.test_client() as client:
+        # Create record
+        res = client.post(
+            search_url, data=json.dumps(test_data[0]), headers=HEADERS)
+        assert res.status_code == 201
+        _id = get_json(res)['id']
         # Delete record.
-        url = record_url(pid)
+        url = record_url(_id)
         assert client.delete(url).status_code == 204
 
         # check patch response for deleted resource
         res = client.patch(url, data=json.dumps(test_patch), headers=HEADERS)
         assert res.status_code == 410
+        IndexFlusher(search_class).flush_and_wait()
+        res = client.get(search_url,
+                         query_string={'title': test_data[0]['title']})
+        assert_hits_len(res, 0)
 
 
 @pytest.mark.parametrize('charset', [
     '', ';charset=utf-8'
 ])
-def test_invalid_patch(app, test_records, test_patch, charset):
+def test_invalid_patch(app, es, test_records, test_patch, charset, search_url,
+                       search_class):
     """Test INVALID record put request (PUT .../records/<record_id>)."""
     HEADERS = [
         ('Accept', 'application/json'),
@@ -100,6 +116,9 @@ def test_invalid_patch(app, test_records, test_patch, charset):
         res = client.patch(
             record_url('0'), data=json.dumps(test_patch), headers=HEADERS)
         assert res.status_code == 404
+        IndexFlusher(search_class).flush_and_wait()
+        res = client.get(search_url)
+        assert_hits_len(res, 0)
 
         # Invalid accept mime type.
         headers = [('Content-Type',

--- a/tests/test_views_list_post.py
+++ b/tests/test_views_list_post.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,7 +30,8 @@ import json
 
 import mock
 import pytest
-from helpers import _mock_validate_fail, get_json, record_url
+from conftest import IndexFlusher
+from helpers import _mock_validate_fail, assert_hits_len, get_json, record_url
 from mock import patch
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -38,7 +39,8 @@ from sqlalchemy.exc import SQLAlchemyError
 @pytest.mark.parametrize('content_type', [
     'application/json', 'application/json;charset=utf-8'
 ])
-def test_valid_create(app, db, test_data, search_url, content_type):
+def test_valid_create(app, db, es, test_data, search_url, search_class,
+                      content_type):
     """Test VALID record creation request (POST .../records/)."""
     with app.test_client() as client:
         HEADERS = [
@@ -66,21 +68,18 @@ def test_valid_create(app, db, test_data, search_url, content_type):
         # Record can be retrieved.
         assert client.get(record_url(data['id'])).status_code == 200
 
-        # Record can be searched (after a moment of time)
-        # Note: Currently we don't index on record creation so this part is
-        # disabled.
-
-        # current_search.flush_and_refresh(search_class.Meta.index)
-        # res = client.get(
-        #     search_url,
-        #     query_string={'q': 'control_number:{}'.format(data['id'])})
-        # assert_hits_len(res, 1)
+        IndexFlusher(search_class).flush_and_wait()
+        # Record shows up in search
+        res = client.get(search_url,
+                         query_string={"control_number":
+                                       data['metadata']['control_number']})
+        assert_hits_len(res, 1)
 
 
 @pytest.mark.parametrize('content_type', [
     'application/json', 'application/json;charset=utf-8'
 ])
-def test_invalid_create(app, db, test_data, search_url, content_type):
+def test_invalid_create(app, db, es, test_data, search_url, content_type):
     """Test INVALID record creation request (POST .../records/)."""
     with app.test_client() as client:
         HEADERS = [
@@ -94,6 +93,9 @@ def test_invalid_create(app, db, test_data, search_url, content_type):
         res = client.post(
             search_url, data=json.dumps(test_data[0]), headers=headers)
         assert res.status_code == 406
+        # check that nothing is indexed
+        res = client.get(search_url, query_string=dict(page=1, size=2))
+        assert_hits_len(res, 0)
 
         # Invalid content-type
         headers = [('Content-Type', 'video/mp4'),
@@ -101,14 +103,20 @@ def test_invalid_create(app, db, test_data, search_url, content_type):
         res = client.post(
             search_url, data=json.dumps(test_data[0]), headers=headers)
         assert res.status_code == 415
+        res = client.get(search_url, query_string=dict(page=1, size=2))
+        assert_hits_len(res, 0)
 
         # Invalid JSON
         res = client.post(search_url, data='{fdssfd', headers=HEADERS)
         assert res.status_code == 400
+        res = client.get(search_url, query_string=dict(page=1, size=2))
+        assert_hits_len(res, 0)
 
         # No data
         res = client.post(search_url, headers=HEADERS)
         assert res.status_code == 400
+        res = client.get(search_url, query_string=dict(page=1, size=2))
+        assert_hits_len(res, 0)
 
         # Posting a list instead of dictionary
         pytest.raises(


### PR DESCRIPTION
* CHANGE indexing of changes after PUT, DELETE, PATCH, POST

* Extend the tests to check for proper indexing
   Closes https://github.com/inveniosoftware/invenio-records-rest/issues/172

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>
Co-authored-by: Diego Rodriguez <diego.rodriguez@cern.ch>