### PR TITLE
sorter: fix unicode handling

### DIFF
--- a/invenio_records_rest/sorter.py
+++ b/invenio_records_rest/sorter.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, print_function
 
 import copy
 
+import six
 from flask import current_app, request
 
 
@@ -115,7 +116,8 @@ def default_sorter_factory(search, index):
 
     # Get default sorting if sort is not specified.
     if not urlfield:
-        has_query = request.values.get('q', type=str)
+        # cast to six.text_type to handle unicodes in Python 2
+        has_query = request.values.get('q', type=six.text_type)
         urlfield = current_app.config['RECORDS_REST_DEFAULT_SORT'].get(
             index, {}).get('query' if has_query else 'noquery', '')
 

--- a/tests/test_sorter.py
+++ b/tests/test_sorter.py
@@ -129,6 +129,13 @@ def test_default_sorter_factory(app):
             [{'field1': {'order': 'desc'}}, {'field2': {'order': 'asc'}}]
         assert urlargs == dict(sort='-myfield')
 
+    # Default sort with query that includes unicodes
+    with app.test_request_context("/?q=tést"):
+        query, urlargs = default_sorter_factory(Search(), 'myindex')
+        assert query.to_dict()['sort'] == \
+            [{'field1': {'order': 'desc'}}, {'field2': {'order': 'asc'}}]
+        assert urlargs == dict(sort='-myfield')
+
     # Default sort another index
     with app.test_request_context("/?q=test"):
         query, urlargs = default_sorter_factory(Search(), 'aidx')


### PR DESCRIPTION
this addresses #189 . I don't know if we want to invest some time on @egabancho suggestion in order to remove `six` from dependency.