### PR TITLE
serializers: drop usage of request.is_xhr for JSON

### DIFF
--- a/invenio_records_rest/serializers/json.py
+++ b/invenio_records_rest/serializers/json.py
@@ -22,15 +22,7 @@ class JSONSerializerMixin(SerializerMixinInterface):
     @staticmethod
     def _format_args():
         """Get JSON dump indentation and separates."""
-        # Ensure we can run outside a application/request context.
-        try:
-            pretty_format = \
-                current_app.config['JSONIFY_PRETTYPRINT_REGULAR'] and \
-                not request.is_xhr
-        except RuntimeError:
-            pretty_format = False
-
-        if pretty_format:
+        if request and request.args.get('prettyprint'):
             return dict(
                 indent=2,
                 separators=(', ', ': '),

--- a/tests/test_serializer_json.py
+++ b/tests/test_serializer_json.py
@@ -78,12 +78,10 @@ def test_serialize_pretty(app):
     pid = PersistentIdentifier(pid_type='recid', pid_value='2'),
     rec = Record({'title': 'test'})
 
-    app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
     with app.test_request_context():
         assert JSONSerializer(TestSchema).serialize(pid, rec) == \
             '{"title":"test"}'
 
-    app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
-    with app.test_request_context():
+    with app.test_request_context('/?prettyprint=1'):
         assert JSONSerializer(TestSchema).serialize(pid, rec) == \
             '{\n  "title": "test"\n}'


### PR DESCRIPTION
* Drops usage of `request.is_xhr` since it's deprecated in
  flask/werkzeug. (closes #204)
* Prints pretty JSON in debug mode.