### PR TITLE
* FIX test_error_handlers invalid-json test

### DIFF
--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -65,7 +65,7 @@ def test_custom_error_handlers(app, db, test_data):
         data = json.loads(res.get_data(as_text=True))
         assert data == {
             'message': (
-                'The browser (or proxy) sent a request that this server could '
-                'not understand.'),
+                'Failed to decode JSON object: Expecting property name '
+                'enclosed in double quotes: line 1 column 2 (char 1)'),
             'status': 400
         }


### PR DESCRIPTION
The ``invalid-json`` test in test_error_handlers was comparing to the wrong string (maybe coming from an old version). After testing with a simple POST and PUT with ``'{invalid-json' as data, it can be seen that the string returned by the server is:

```'Failed to decode JSON object: Expecting property name  enclosed in double quotes: line 1 column 2 (char 1)```
