### PR TITLE
Refactor: change naming of 'read_list' permissions to 'list' 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.1.2 (released 2018-06-26)
+
+- Rename authentication of GET operation over
+  RecordsListResource from 'read_list' to 'list'.
+
 Version 1.1.1 (released 2018-06-25)
 
 - Adds authentication to GET operation over

--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -96,7 +96,7 @@ The structure of the dictionary is as follows:
             'pid_fetcher': '<registered-pid-fetcher>',
             'pid_minter': '<registered-minter-name>',
             'pid_type': '<record-pid-type>',
-            'read_list_permission_factory_imp': permission_check_factory(),
+            'list_permission_factory_imp': permission_check_factory(),
             'read_permission_factory_imp': permission_check_factory(),
             'record_class': 'mypackage.api:MyRecord',
             'record_loaders': {
@@ -159,8 +159,8 @@ The structure of the dictionary is as follows:
 
 :param pid_minter: It identifies the registered minter name. Required.
 
-:param read_list_permission_factory_imp: Import path to factory that creates a
-    read list permission object for a given index / list.
+:param list_permission_factory_imp: Import path to factory that creates a
+    list permission object for a given index / list.
 
 :param read_permission_factory_imp: Import path to factory that creates a
     read permission object for a given record.
@@ -336,8 +336,8 @@ The structure of the dictionary is as follows:
 RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY = deny_all
 """Default create permission factory: reject any request."""
 
-RECORDS_REST_DEFAULT_READ_LIST_PERMISSION_FACTORY = allow_all
-"""Default read list permission factory: allow all requests"""
+RECORDS_REST_DEFAULT_LIST_PERMISSION_FACTORY = allow_all
+"""Default list permission factory: allow all requests"""
 
 RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY = check_elasticsearch
 """Default read permission factory: check if the record exists."""

--- a/invenio_records_rest/ext.py
+++ b/invenio_records_rest/ext.py
@@ -61,10 +61,10 @@ class _RecordRESTState(object):
         )
 
     @cached_property
-    def read_list_permission_factory(self):
+    def list_permission_factory(self):
         """Load default read permission factory."""
         return load_or_import_from_config(
-            'RECORDS_REST_DEFAULT_READ_LIST_PERMISSION_FACTORY', app=self.app
+            'RECORDS_REST_DEFAULT_LIST_PERMISSION_FACTORY', app=self.app
         )
 
     @cached_property

--- a/invenio_records_rest/version.py
+++ b/invenio_records_rest/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -160,7 +160,7 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
                      create_permission_factory_imp=None,
                      update_permission_factory_imp=None,
                      delete_permission_factory_imp=None,
-                     read_list_permission_factory_imp=None,
+                     list_permission_factory_imp=None,
                      record_class=None,
                      record_serializers=None,
                      record_serializers_aliases=None,
@@ -190,8 +190,8 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
         update permission object for a given record.
     :param delete_permission_factory_imp: Import path to factory that creates a
         delete permission object for a given record.
-    :param read_list_permission_factory_imp: Import path to factory that
-        creates a read list permission object for a given index/list.
+    :param list_permission_factory_imp: Import path to factory that
+        creates a list permission object for a given index/list.
     :param default_endpoint_prefix: ignored.
     :param record_class: A record API class or importable string.
     :param record_serializers: Serializers used for records.
@@ -242,8 +242,8 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
     delete_permission_factory = obj_or_import_string(
         delete_permission_factory_imp
     )
-    read_list_permission_factory = obj_or_import_string(
-        read_list_permission_factory_imp
+    list_permission_factory = obj_or_import_string(
+        list_permission_factory_imp
     )
     links_factory = obj_or_import_string(
         links_factory_imp, default=default_links_factory
@@ -300,7 +300,7 @@ def create_url_rules(endpoint, list_route=None, item_route=None,
         pid_fetcher=pid_fetcher,
         read_permission_factory=read_permission_factory,
         create_permission_factory=create_permission_factory,
-        read_list_permission_factory=read_list_permission_factory,
+        list_permission_factory=list_permission_factory,
         record_serializers=record_serializers,
         record_loaders=record_loaders,
         search_serializers=search_serializers,
@@ -467,7 +467,7 @@ class RecordsListResource(ContentNegotiatedMethodView):
     def __init__(self, resolver=None, minter_name=None, pid_type=None,
                  pid_fetcher=None, read_permission_factory=None,
                  create_permission_factory=None,
-                 read_list_permission_factory=None,
+                 list_permission_factory=None,
                  search_class=None,
                  record_serializers=None,
                  record_loaders=None,
@@ -494,8 +494,8 @@ class RecordsListResource(ContentNegotiatedMethodView):
         self.read_permission_factory = read_permission_factory
         self.create_permission_factory = create_permission_factory or \
             current_records_rest.create_permission_factory
-        self.read_list_permission_factory = read_list_permission_factory or \
-            current_records_rest.read_list_permission_factory
+        self.list_permission_factory = list_permission_factory or \
+            current_records_rest.list_permission_factory
         self.search_class = search_class
         self.max_result_window = max_result_window or 10000
         self.search_factory = partial(search_factory, self)
@@ -505,11 +505,11 @@ class RecordsListResource(ContentNegotiatedMethodView):
         self.record_class = record_class or Record
         self.indexer_class = indexer_class
 
-    @need_record_permission('read_list_permission_factory')
+    @need_record_permission('list_permission_factory')
     def get(self, **kwargs):
         """Search records.
 
-        Permissions: the `read_list_permission_factory` permissions are
+        Permissions: the `list_permission_factory` permissions are
             checked.
 
         :returns: Search result containing hits and aggregations as


### PR DESCRIPTION
Change naming of 'read_list' permissions to 'list' for better consistency