### PR TITLE
schemas: Nested class w/out recursive error check

### DIFF
--- a/invenio_records_rest/schemas/__init__.py
+++ b/invenio_records_rest/schemas/__init__.py
@@ -10,9 +10,10 @@
 
 from __future__ import absolute_import, print_function
 
-from .json import RecordSchemaJSONV1, StrictKeysMixin
+from .json import Nested, RecordSchemaJSONV1, StrictKeysMixin
 
 __all__ = (
     'RecordSchemaJSONV1',
     'StrictKeysMixin',
+    'Nested'
 )

--- a/invenio_records_rest/schemas/json.py
+++ b/invenio_records_rest/schemas/json.py
@@ -10,7 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
-from marshmallow import Schema, ValidationError, fields, validates_schema
+from marshmallow import Schema, ValidationError, fields, missing, \
+    validates_schema
 
 
 class StrictKeysMixin(Schema):
@@ -40,3 +41,12 @@ class RecordSchemaJSONV1(Schema):
     links = fields.Raw()
     created = fields.Str()
     updated = fields.Str()
+
+
+class Nested(fields.Nested):
+    """Custom Nested class to not recursively check errors."""
+
+    def _validate_missing(self, value):
+        if value is missing and getattr(self, 'required', False):
+            self.fail('required')
+        return super()._validate_missing(value)


### PR DESCRIPTION
* ADD Nested class which overrides the _validate_missing method,
  and reports errors for the topmost missing fields.

Closes #223 

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>