### PR TITLE
views: suggesters support source filtering for ES5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.2.1 (released 2018-09-17)
+
+- Adds source filtering support for ES 5.
+
 Version 1.2.0 (released 2018-08-24)
 
 - Adds PersistentIdentifier field to handle record PIDs.

--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -114,6 +114,7 @@ The structure of the dictionary is as follows:
             'search_type': 'elasticsearch-doc-type',
             'suggesters': {
                 'my_url_param_to_complete': {
+                    '_source': ['specified_source_filtered_field'],
                     'completion': {
                         'field': 'suggest_byyear_elasticsearch_field',
                         'size': 10,
@@ -192,9 +193,11 @@ The structure of the dictionary is as follows:
 :param search_type: Name of the search type used when searching records.
 
 :param suggesters: Suggester fields configuration. Any element of the
-    dictionary represents a suggestion field. The key of the dictionary element
-    is used to identify the url query parameter. The ``field`` parameter
-    identifies the suggester field name in your elasticsearch schema.
+    dictionary represents a suggestion field. For each suggestion field we can
+    optionally specify the source filtering (appropriate for ES5) by using
+    ``_source``. The key of the dictionary element is used to identify the url
+    query parameter. The ``field`` parameter identifies the suggester field
+    name in your elasticsearch schema.
     To have more information about suggestion configuration, you can read
     suggesters section on ElasticSearch documentation.
 

--- a/invenio_records_rest/version.py
+++ b/invenio_records_rest/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.1.dev20180824'
+__version__ = '1.2.1'

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -841,7 +841,11 @@ class SuggestResource(MethodView):
         # Add completions
         s = self.search_class()
         for field, val, opts in completions:
-            s = s.suggest(field, val, **opts)
+            source = opts.pop('_source', None)
+            if source is not None and ES_VERSION[0] >= 5:
+                s = s.source(source).suggest(field, val, **opts)
+            else:
+                s = s.suggest(field, val, **opts)
 
         if ES_VERSION[0] == 2:
             # Execute search

--- a/tests/test_views_suggesters.py
+++ b/tests/test_views_suggesters.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, print_function
 import json
 
 import pytest
+from elasticsearch import VERSION as ES_VERSION
 from flask import url_for
 
 
@@ -24,7 +25,11 @@ from flask import url_for
                 field='suggest_title')),
             text_byyear=dict(completion=dict(
                 field='suggest_byyear',
-                context='year'))
+                context='year')),
+            text_filtered_source=dict(
+                _source=['control_number'],
+                completion=dict(
+                    field='suggest_title')),
         )
     )
 )], indirect=['app'])
@@ -53,13 +58,34 @@ def test_valid_suggest(app, db, es, indexed_records):
             'title': 'Back to the Future',
             'year': 2015
         }
+        exp1_es5 = {
+            'control_number': '1',
+        }
         exp2 = {
             'control_number': '2',
             'stars': 3,
             'title': 'Back to the Past',
             'year': 2042
         }
+        exp2_es5 = {
+            'control_number': '2',
+        }
         assert all(is_option(exp, options) for exp in [exp1, exp2])
+
+        # Valid simple completion suggester with source filtering for ES5
+        res = client.get(
+            url_for('invenio_records_rest.recid_suggest'),
+            query_string={'text_filtered_source': 'Back'}
+        )
+        assert res.status_code == 200
+        data = json.loads(res.get_data(as_text=True))
+        assert len(data['text_filtered_source'][0]['options']) == 2
+        options = data['text_filtered_source'][0]['options']
+        assert all('_source' in op for op in options)
+
+        exp_fi1 = exp1_es5 if ES_VERSION[0] >= 5 else exp1
+        exp_fi2 = exp2_es5 if ES_VERSION[0] >= 5 else exp2
+        assert all(is_option(exp, options) for exp in [exp_fi1, exp_fi2])
 
         # Valid simple completion suggester with size
         res = client.get(


### PR DESCRIPTION
Make ES5 suggesters support [source filtering](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-source-filtering.html) in order to save network overhead by filtering out useless fields from the `_source` key (or just strip `_source` altogether) returned in the response.
Suggester fields configuration should now contain a `_source` key that will specify the source filtering for each suggestion field. The possible values for the `_source` key are the same as the ones specified in source filtering documentation.

Example configuration:
```
'suggesters': {
        'author': {
            '_source': ['name', 'age'],
            'completion': {
                'field': 'author_suggest',
            },
        }
}
```

With the current test structure, it is not possible to add a reliable test to handle both ES2 and ES5.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>