### PR TITLE
Marshmallow schema and field updates for PID and other helpers

### DIFF
--- a/invenio_records_rest/loaders/__init__.py
+++ b/invenio_records_rest/loaders/__init__.py
@@ -9,7 +9,7 @@
 """Loaders for deserializing records in the REST API."""
 
 from .marshmallow import json_patch_loader, marshmallow_loader
-from ..schemas import RecordSchemaJSONV1
+from ..schemas import RecordSchemaJSONV1, RecordMetadataSchemaJSONV1
 
 json_v1 = marshmallow_loader(RecordSchemaJSONV1)
 """Simple example loader that will take any JSON."""
@@ -17,7 +17,10 @@ json_v1 = marshmallow_loader(RecordSchemaJSONV1)
 json_patch_v1 = json_patch_loader
 """Simple example loader that will take any JSON patch."""
 
+json_pid_checker = marshmallow_loader(RecordMetadataSchemaJSONV1)
+
 __all__ = (
     'json_v1',
     'json_patch_loader',
+    'json_pid_checker'
 )

--- a/invenio_records_rest/schemas/__init__.py
+++ b/invenio_records_rest/schemas/__init__.py
@@ -10,10 +10,11 @@
 
 from __future__ import absolute_import, print_function
 
-from .json import Nested, RecordSchemaJSONV1, StrictKeysMixin
+from .json import Nested, RecordSchemaJSONV1, StrictKeysMixin, RecordMetadataSchemaJSONV1
 
 __all__ = (
     'RecordSchemaJSONV1',
     'StrictKeysMixin',
-    'Nested'
+    'Nested',
+    'RecordMetadataSchemaJSONV1'
 )

--- a/invenio_records_rest/schemas/fields/__init__.py
+++ b/invenio_records_rest/schemas/fields/__init__.py
@@ -9,6 +9,7 @@
 """Custom marshmallow fields."""
 
 from .datetime import DateString
+from .generated import Generated
 from .persistentidentifier import PersistentIdentifier
 from .sanitizedhtml import SanitizedHTML
 from .sanitizedunicode import SanitizedUnicode
@@ -19,5 +20,6 @@ __all__ = (
     'SanitizedHTML',
     'SanitizedUnicode',
     'TrimmedString',
-    'PersistentIdentifier',
+    'Generated',
+    'PersistentIdentifier'
 )

--- a/invenio_records_rest/schemas/fields/__init__.py
+++ b/invenio_records_rest/schemas/fields/__init__.py
@@ -9,7 +9,8 @@
 """Custom marshmallow fields."""
 
 from .datetime import DateString
-from .generated import Generated
+from .generated import GenFunction, GenMethod
+from .marshmallow_contrib import Function, Method
 from .persistentidentifier import PersistentIdentifier
 from .sanitizedhtml import SanitizedHTML
 from .sanitizedunicode import SanitizedUnicode
@@ -17,9 +18,12 @@ from .trimmedstring import TrimmedString
 
 __all__ = (
     'DateString',
+    'Function',
+    'GenFunction',
+    'GenMethod',
+    'Method',
+    'PersistentIdentifier',
     'SanitizedHTML',
     'SanitizedUnicode',
     'TrimmedString',
-    'Generated',
-    'PersistentIdentifier'
 )

--- a/invenio_records_rest/schemas/fields/generated.py
+++ b/invenio_records_rest/schemas/fields/generated.py
@@ -10,46 +10,47 @@
 
 from __future__ import absolute_import, print_function
 
-from marshmallow import fields
+import warnings
 
-from invenio_records_rest.utils import obj_or_import_string
+from .marshmallow_contrib import Function, Method
 
 
-class Generated(fields.Field):
-    """Custom Generate class to inject PID from context."""
+class GeneratedValue(object):
+    """Sentinel value class forcing marshmallow missing field generation."""
 
-    def __init__(self, ser_callback=None, de_callback=None, *args, **kwargs):
-        """Enforce deserialization."""
-        if de_callback:
-            kwargs['missing'] = None  # enforce calling `deseralize`
-            deserializer = obj_or_import_string(de_callback)
-            self._de_callback = deserializer
-        if ser_callback:
-            kwargs['default'] = None
-            serializer = obj_or_import_string(ser_callback)
-            self._ser_callback = serializer
+    pass
 
-        super(Generated, self).__init__(*args, **kwargs)
 
-    def serialize(self, attr, obj, accessor=None):
-        """Serialize by returning the value of missing."""
-        """Get PID value from context."""
-        if self._ser_callback:
-            if isinstance(self._ser_callback, str):
-                func = getattr(self.parent, self._ser_callback)
-                return func()
+class ForcedFieldDeserializeMixin(object):
+    """Mixin that forces deserialization of marshmallow fields."""
 
-            return self._ser_callback(self.parent, attr, obj, accessor)
-        else:
-            super(Generated, self)._serialize(attr, obj, accessor)
+    def __init__(self, *args, **kwargs):
+        """Override the "missing" parameter."""
+        if 'missing' in kwargs:
+            obj_name = '{self.__module__}.{self.__class__.__name__}'.format(
+                self=self)
+            mixin_name = '{mixin.__module__}.{mixin.__name__}'.format(
+                mixin=ForcedFieldDeserializeMixin)
+            warnings.warn(
+                '[{obj_name}] is overriding the "missing" argument via '
+                '[{mixin_name}] in order to enforce deserialization of the '
+                'Marshmallow field. The value "{original_missing}" will be '
+                'overridden.'.format(
+                    obj_name=obj_name, mixin_name=mixin_name,
+                    original_missing=kwargs['missing']),
+                RuntimeWarning)
+        # Setting "missing" to some value forces the call to ``.deserialize``
+        kwargs['missing'] = GeneratedValue
+        super(ForcedFieldDeserializeMixin, self).__init__(*args, **kwargs)
 
-    def deserialize(self, value, attr=None, data=None):
-        """Get PID value from context."""
-        if self._de_callback:
-            if isinstance(self._de_callback, str):
-                func = getattr(self.parent, self._de_callback)
-                return func()
 
-            return self._de_callback(self.parent, value, attr, data)
-        else:
-            super(Generated, self)._deserialize(value, attr, data)
+class GenFunction(ForcedFieldDeserializeMixin, Function):
+    """Function field which is always deserialized."""
+
+    pass
+
+
+class GenMethod(ForcedFieldDeserializeMixin, Method):
+    """Method field which is always deserialized."""
+
+    pass

--- a/invenio_records_rest/schemas/fields/generated.py
+++ b/invenio_records_rest/schemas/fields/generated.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Generated field."""
+
+from __future__ import absolute_import, print_function
+
+from marshmallow import fields
+
+from invenio_records_rest.utils import obj_or_import_string
+
+
+class Generated(fields.Field):
+    """Custom Generate class to inject PID from context."""
+
+    def __init__(self, ser_callback=None, de_callback=None, *args, **kwargs):
+        """Enforce deserialization."""
+        if de_callback:
+            kwargs['missing'] = None  # enforce calling `deseralize`
+            deserializer = obj_or_import_string(de_callback)
+            self._de_callback = deserializer
+        if ser_callback:
+            kwargs['default'] = None
+            serializer = obj_or_import_string(ser_callback)
+            self._ser_callback = serializer
+
+        super(Generated, self).__init__(*args, **kwargs)
+
+    def serialize(self, attr, obj, accessor=None):
+        """Serialize by returning the value of missing."""
+        """Get PID value from context."""
+        if self._ser_callback:
+            if isinstance(self._ser_callback, str):
+                func = getattr(self.parent, self._ser_callback)
+                return func()
+
+            return self._ser_callback(self.parent, attr, obj, accessor)
+        else:
+            super(Generated, self)._serialize(attr, obj, accessor)
+
+    def deserialize(self, value, attr=None, data=None):
+        """Get PID value from context."""
+        if self._de_callback:
+            if isinstance(self._de_callback, str):
+                func = getattr(self.parent, self._de_callback)
+                return func()
+
+            return self._de_callback(self.parent, value, attr, data)
+        else:
+            super(Generated, self)._deserialize(value, attr, data)

--- a/invenio_records_rest/schemas/fields/marshmallow_contrib.py
+++ b/invenio_records_rest/schemas/fields/marshmallow_contrib.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Contributed Marshmallow fields."""
+
+from __future__ import absolute_import, print_function
+
+import functools
+import inspect
+
+from marshmallow import fields, utils
+
+
+def _get_func_args(func):
+    """Get a list of the arguments a function or method has."""
+    if isinstance(func, functools.partial):
+        return _get_func_args(func.func)
+    if inspect.isfunction(func) or inspect.ismethod(func):
+        return list(inspect.getargspec(func).args)
+    if callable(func):
+        return list(inspect.getargspec(func.__call__).args)
+
+
+class Function(fields.Function):
+    """Enhanced marshmallow Function field.
+
+    The main difference between the original marshmallow.fields.Function is for
+    the ``deserialize`` function, which can now also point to a three-argument
+    function, with the third argument being the original data that was passed
+    to ``Schema.load``. The following example better demonstrates how this
+    works:
+
+    .. code-block:: python
+
+        def serialize_foo(obj, context):
+            return {'serialize_args': {'obj': obj, 'context': context}}
+
+        def deserialize_foo(value, context, data):
+            return {'deserialize_args': {
+                'value': value, 'context': context, 'data': data}}
+
+        class FooSchema(marshmallow.Schema):
+
+            foo = Function(serialize_foo, deserialize_foo)
+
+        FooSchema().dump({'foo': 42}).data
+        {'foo': {
+            'serialize_args': {
+                'obj': {'foo': 42},
+                'context': {}  # no context was passed
+            }
+        }}
+
+        FooSchema().load({'foo': 42}).data
+        {'foo': {
+            'deserialize_args': {
+                'value': 42,
+                'context': {},  # no context was passed
+                'data': {'foo': 42},
+            }
+        }}
+    """
+
+    def _deserialize(self, value, attr, data):
+        if self.deserialize_func:
+            return self._call_or_raise(
+                self.deserialize_func, value, attr, data)
+        return value
+
+    def _call_or_raise(self, func, value, attr, data=None):
+        func_args_len = len(_get_func_args(func))
+        if func_args_len > 2:
+            return func(value, self.parent.context, data)
+        elif func_args_len > 1:
+            return func(value, self.parent.context)
+        else:
+            return func(value)
+
+
+class Method(fields.Method):
+    """Enhanced marshmallow Method field.
+
+    The main difference between the original marshmallow.fields.Method is for
+    the ``deserialize`` method, which can now also point to a two-argument
+    method, with the second argument being the original data that was passed to
+    ``Schema.load``. The following example better demonstrates how this works:
+
+    .. code-block:: python
+
+        class BarSchema(marshmallow.Schema):
+
+            bar = Method('serialize_bar', 'deserialize_bar')
+
+            # Exactly the same behavior as in ``marshmallow.fields.Method``
+            def serialize_bar(self, obj):
+                return {'serialize_args': {'obj': obj}}
+
+            def deserialize_bar(self, value, data):
+                return {'deserialize_args': {'value': value, 'data': data}}
+
+        BarSchema().dump({'bar': 42}).data
+        {'bar': {
+            'serialize_args': {
+                'obj': {'bar': 42}
+            }
+        }}
+
+        BarSchema().load({'bar': 42}).data
+        {'bar': {
+            'deserialize_args': {
+                'data': {'bar': 42},
+                'value': 42
+            }
+        }}
+    """
+
+    def _deserialize(self, value, attr, data):
+        if self.deserialize_method_name:
+            try:
+                method = utils.callable_or_raise(
+                    getattr(self.parent, self.deserialize_method_name, None)
+                )
+                method_args_len = len(_get_func_args(method))
+                if method_args_len > 2:
+                    return method(value, data)
+                return method(value)
+            except AttributeError:
+                pass
+        return value

--- a/invenio_records_rest/schemas/fields/persistentidentifier.py
+++ b/invenio_records_rest/schemas/fields/persistentidentifier.py
@@ -10,24 +10,16 @@
 
 from marshmallow import missing
 
-from invenio_records_rest.schemas.fields import Generated
+from invenio_records_rest.schemas.fields.generated import GenFunction
 
 
-def default_pid_deserializer(schema, value, attr, accesor):
-    """Custom PID deserializer function."""
-    if schema.context and schema.context.get('pid'):
-        pid = schema.context.get('pid')
-        return pid.pid_value
-    return missing
+def pid_from_context(_, context):
+    """Get PID from marshmallow context."""
+    pid = (context or {}).get('pid')
+    return pid.pid_value if pid else missing
 
 
-def default_pid_serializer(schema, value, attr, data):
-    """Custom PID serializer function."""
-    pid = schema.context.get('pid')
-    return pid.pid_value
-
-
-class PersistentIdentifier(Generated):
+class PersistentIdentifier(GenFunction):
     """Field to handle PersistentIdentifiers in records.
 
     .. versionadded:: 1.2.0
@@ -35,6 +27,6 @@ class PersistentIdentifier(Generated):
 
     def __init__(self, *args, **kwargs):
         """Initialize field."""
-        super(PersistentIdentifier, self).__init__(default_pid_serializer,
-                                                   default_pid_deserializer,
-                                                   *args, **kwargs)
+        super(PersistentIdentifier, self).__init__(
+            serialize=pid_from_context, deserialize=pid_from_context,
+            *args, **kwargs)

--- a/invenio_records_rest/schemas/fields/persistentidentifier.py
+++ b/invenio_records_rest/schemas/fields/persistentidentifier.py
@@ -8,19 +8,33 @@
 
 """Persistent Identifier field."""
 
-from marshmallow import fields, missing
+from marshmallow import missing
+
+from invenio_records_rest.schemas.fields import Generated
 
 
-class PersistentIdentifier(fields.Field):
+def default_pid_deserializer(schema, value, attr, accesor):
+    """Custom PID deserializer function."""
+    if schema.context and schema.context.get('pid'):
+        pid = schema.context.get('pid')
+        return pid.pid_value
+    return missing
+
+
+def default_pid_serializer(schema, value, attr, data):
+    """Custom PID serializer function."""
+    pid = schema.context.get('pid')
+    return pid.pid_value
+
+
+class PersistentIdentifier(Generated):
     """Field to handle PersistentIdentifiers in records.
 
     .. versionadded:: 1.2.0
     """
 
-    def _serialize(self, value, attr, context):
-        pid = context.get('pid')
-        return pid.pid_value if pid else missing
-
-    def _deserialize(self, value, attr, context):
-        pid = context.get('pid')
-        return pid.get('pid_value') if pid else missing
+    def __init__(self, *args, **kwargs):
+        """Initialize field."""
+        super(PersistentIdentifier, self).__init__(default_pid_serializer,
+                                                   default_pid_deserializer,
+                                                   *args, **kwargs)

--- a/invenio_records_rest/schemas/json.py
+++ b/invenio_records_rest/schemas/json.py
@@ -82,8 +82,8 @@ class RecordMetadataSchemaJSONV1(OriginalKeysMixin):
     @post_load()
     def inject_pid(self, data):
         """Inject context PID in the RECID field."""
-        # Use the already deserialized "pid" field
-        pid_value = data.get('pid')
+        # Remove already deserialized "pid" field
+        pid_value = data.pop('pid', None)
         if pid_value:
             pid_field = current_app.config['PIDSTORE_RECID_FIELD']
             data.setdefault(pid_field, pid_value)

--- a/invenio_records_rest/serializers/json.py
+++ b/invenio_records_rest/serializers/json.py
@@ -10,7 +10,7 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import current_app, json, request
+from flask import json, request
 
 from .base import PreprocessorMixin, SerializerMixinInterface
 from .marshmallow import MarshmallowMixin

--- a/tests/data/testrecords.json
+++ b/tests/data/testrecords.json
@@ -2,25 +2,21 @@
   {
     "year": 2015,
     "stars": 4,
-    "title": "Back to the Future",
-    "pid": {"pid_value": 1, "pid_type": "recid"}
+    "title": "Back to the Future"
   },
   {
     "year": 2042,
     "stars": 3,
-    "title": "Back to the Past",
-    "pid": {"pid_value": 2, "pid_type": "recid"}
+    "title": "Back to the Past"
   },
   {
     "year": 1985,
     "stars": 4,
-    "title": "The Hitchhiker's Guide to the Galaxy",
-    "pid": {"pid_value": 3, "pid_type": "recid"}
+    "title": "The Hitchhiker's Guide to the Galaxy"
   },
   {
     "year": 4242,
     "stars": 5,
-    "title": "Unknown film",
-    "pid": {"pid_value": 4, "pid_type": "recid"}
+    "title": "Unknown film"
   }
 ]

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -8,11 +8,15 @@
 
 """Invenio custom schema fields tests."""
 
+import pytest
+from invenio_pidstore.models import PersistentIdentifier as PIDModel
 from invenio_records import Record
+from marshmallow import missing
 
 from invenio_records_rest.schemas import StrictKeysMixin
-from invenio_records_rest.schemas.fields import DateString, SanitizedHTML, \
-    SanitizedUnicode, TrimmedString
+from invenio_records_rest.schemas.fields import DateString, GenFunction, \
+    GenMethod, PersistentIdentifier, SanitizedHTML, SanitizedUnicode, \
+    TrimmedString
 
 
 class CustomFieldSchema(StrictKeysMixin):
@@ -24,24 +28,120 @@ class CustomFieldSchema(StrictKeysMixin):
         attribute='sanitized_unicode_field')
     trimmed_string_field = TrimmedString(
         attribute='trimmed_string_field')
+    gen_function_field = GenFunction(
+        lambda o: 'serialize_gen_function_field',
+        lambda o: 'deserialize_gen_function_field',
+    )
+    gen_method_field = GenMethod(
+        'serialize_gen_method_field',
+        'deserialize_gen_method_field')
+    persistent_identifier_field = PersistentIdentifier()
+
+    def serialize_gen_method_field(self, obj):
+        """Serialize a value for the GenMethod field."""
+        return 'serialize_gen_method_field'
+
+    def deserialize_gen_method_field(self, value):
+        """Deserialize a value for the GenMethod field."""
+        return 'deserialize_gen_method_field'
 
 
 def test_load_custom_fields(app):
-    """Test pretty JSON."""
+    """Test loading of custom fields."""
     rec = Record({'date_string_field': '27.10.1999',
                   'sanitized_html_field': 'an <script>evil()</script> example',
                   # Zero-width space, Line Tabulation, Escape, Cancel
                   'sanitized_unicode_field': u'\u200b\u000b\u001b\u0018',
                   'trimmed_string_field': 'so much trailing whitespace    '})
+    recid = PIDModel(pid_type='recid', pid_value='12345')
+    # ensure only valid keys are given
+    CustomFieldSchema().check_unknown_fields(rec, rec)
+    loaded_data = CustomFieldSchema(context={'pid': recid}).load(rec).data
+    if 'metadata' in loaded_data:
+        values = loaded_data['metadata'].values()
+    else:
+        values = loaded_data.values()
+    assert set(values) == \
+        set(['1999-10-27', 'so much trailing whitespace',
+             'an evil() example', u'', '12345',
+             'deserialize_gen_method_field', 'deserialize_gen_function_field'])
 
-    with app.test_request_context():
-        # ensure only valid keys are given
-        CustomFieldSchema().check_unknown_fields(rec, rec)
-        loaded_data = CustomFieldSchema().load(rec).data
-        if 'metadata' in loaded_data:
-            values = loaded_data['metadata'].values()
-        else:
-            values = loaded_data.values()
-        assert set(values) == \
-            set(['1999-10-27', 'so much trailing whitespace',
-                 'an evil() example', u''])
+
+def test_custom_generated_fields():
+    """Test fields.generated fields."""
+
+    with pytest.warns(RuntimeWarning):
+        def serialize_func(obj, ctx):
+            return ctx.get('func-foo', obj.get('func-bar', missing))
+
+        def deserialize_func(value, ctx, data):
+            return ctx.get('func-foo', data.get('func-bar', missing))
+
+        class GeneratedFieldsSchema(StrictKeysMixin):
+            """Test schema."""
+
+            gen_function = GenFunction(
+                serialize=serialize_func,
+                deserialize=deserialize_func,
+            )
+
+            gen_method = GenMethod(
+                serialize='_serialize_gen_method',
+                deserialize='_desererialize_gen_method',
+                missing='raises-warning',
+            )
+
+            def _serialize_gen_method(self, obj):
+                # "meth-foo" from context or "meth-bar" from the object
+                return self.context.get(
+                    'meth-foo', obj.get('meth-bar', missing))
+
+            def _desererialize_gen_method(self, value, data):
+                # "meth-foo" from context or "meth-bar" from the data
+                return self.context.get(
+                    'meth-foo', data.get('meth-bar', missing))
+
+    ctx = {
+        'func-foo': 'ctx-func-value',
+        'meth-foo': 'ctx-meth-value',
+    }
+    data = {
+        'func-bar': 'data-func-value',
+        'meth-bar': 'data-meth-value',
+        'gen_function': 'original-func-value',
+        'gen_method': 'original-meth-value',
+    }
+
+    # No context, no data
+    assert GeneratedFieldsSchema().load({}).data == {}
+    assert GeneratedFieldsSchema().dump({}).data == {}
+
+    # Only context
+    assert GeneratedFieldsSchema(context=ctx).load({}).data == {
+        'gen_function': 'ctx-func-value',
+        'gen_method': 'ctx-meth-value',
+    }
+    assert GeneratedFieldsSchema(context=ctx).dump({}).data == {
+        'gen_function': 'ctx-func-value',
+        'gen_method': 'ctx-meth-value',
+    }
+
+    # Only data
+    assert GeneratedFieldsSchema().load(data).data == {
+        'gen_function': 'data-func-value',
+        'gen_method': 'data-meth-value',
+    }
+    assert GeneratedFieldsSchema().dump(data).data == {
+        'gen_function': 'data-func-value',
+        'gen_method': 'data-meth-value',
+    }
+
+    # Context and data
+    assert GeneratedFieldsSchema(context=ctx).load(data).data == {
+        'gen_function': 'ctx-func-value',
+        'gen_method': 'ctx-meth-value',
+    }
+    assert GeneratedFieldsSchema(context=ctx).dump(data).data == {
+        'gen_function': 'ctx-func-value',
+        'gen_method': 'ctx-meth-value',
+    }


### PR DESCRIPTION
Fixes: https://github.com/inveniosoftware/invenio-records-rest/issues/232
Fixes: [cookiecutter-invenio-instance#97](https://github.com/inveniosoftware/cookiecutter-invenio-instance#97)
In order to use it the loader should be overwritten with:

```python
record_loaders={
            'application/json': ('invenio_records_rest.loaders:json_pid_checker')
        },
```

And add the PID attribute name on the environment / config file:

```python
[ INVENIO_ ]RECORDS_REST_PID_ATTR_NAME = 'control_number'
```

For the code:

- Should the "get_pid" function be customizable (e.g. through ``import_string()``)? If not, is ``json.py`` the best place to be for this function, ``utils.py``?
- There is a test file for [custom marshmallow loaders](https://github.com/inveniosoftware/invenio-records-rest/blob/master/tests/test_marshmallow_loader.py). Should it be overwritten? Should I create a new one? Mainly to comply with coveralls.

For the tests:

- Create record (post), chek record PID.
- Update with wrong PID, check it does not change (search + DB)
- Update with no PID, check it does not change (search + DB)

Small punctualization: In order to follow the naming convention of this repo/other invenio repos, shouldn't the file be named ``test_loader_marshmallow`` instead of ``test_marshmallow_loader`` (e.g. check the serializers).