### PR TITLE
error handling: return serializable unhandled error

### DIFF
--- a/invenio_records_rest/errors.py
+++ b/invenio_records_rest/errors.py
@@ -187,3 +187,11 @@ class JSONSchemaValidationError(RESTValidationError):
         super(RESTValidationError, self).__init__(**kwargs)
         self.description = 'Validation error: {0}.'.format(
             error.message if error else '')
+
+
+class UnhandledElasticsearchError(RESTException):
+    """Failed to handle exception."""
+
+    code = 500
+    description = 'An internal server error occurred when handling the ' \
+                  'request.'

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -39,7 +39,7 @@ from .errors import InvalidDataRESTError, InvalidQueryRESTError, \
     JSONSchemaValidationError, MaxResultWindowRESTError, \
     PatchJSONFailureRESTError, PIDResolveRESTError, \
     SuggestMissingContextRESTError, SuggestNoCompletionsRESTError, \
-    UnsupportedMediaRESTError
+    UnhandledElasticsearchError, UnsupportedMediaRESTError
 from .links import default_links_factory
 from .proxies import current_records_rest
 from .query import es_search_factory
@@ -95,7 +95,11 @@ def create_error_handlers(blueprint, error_handlers_registry=None):
         for cause_type, handler in handlers.items():
             if cause_type in cause_types:
                 return handler(error)
-        return error
+
+        # Default exception for unhandled errors
+        exception = UnhandledElasticsearchError()
+        current_app.logger.exception(error)  # Log the original stacktrace
+        return exception.get_response()
 
     for exc_or_code, handlers in error_handlers_registry.items():
         # Build full endpoint names and resolve handlers


### PR DESCRIPTION
* Adds an exception that inherits from  REST Exception and represents an unhandled exception.
* Logs the exception so it goes to Sentry/Logging.
* Returns a serializable response so the App does not crash (Internal Server Error).
* Users should change ``RECORDS_REST_ELASTICSEARCH_ERROR_HANDLERS`` to adapt the errors to their needs (e.g. return parsing errors, which at the moment are not handled).
Closes https://github.com/inveniosoftware/invenio-indexer/issues/88
Outdates https://github.com/inveniosoftware/troubleshooting/issues/24