### PR TITLE
WIP: views: allow ES indexing parameters from POST request

### DIFF
--- a/invenio_records_rest/utils.py
+++ b/invenio_records_rest/utils.py
@@ -112,6 +112,25 @@ def check_elasticsearch(record, *args, **kwargs):
     return type('CheckES', (), {'can': can})()
 
 
+def parse_elasticsearch_index_params(values):
+    """
+    Parses the possible parameters for indexing a record into Elasticsearch.
+
+    :param values: A dictionary with the values of the request.
+    :return: A dictionary with the parameters for indexing.
+    """
+    params_list = ['pipeline', 'refresh', 'routing', 'timeout', 'timestamp',
+                   'ttl', 'version', 'version_type', 'wait_for_active_shards']
+
+    params = {}
+    for param in params_list:
+        value = values.get(param, None)
+        if value:
+            params[param] = value
+
+    return params
+
+
 class LazyPIDValue(object):
     """Lazy PID resolver.
 

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -43,7 +43,7 @@ from .errors import InvalidDataRESTError, InvalidQueryRESTError, \
 from .links import default_links_factory
 from .proxies import current_records_rest
 from .query import es_search_factory
-from .utils import obj_or_import_string
+from .utils import obj_or_import_string, parse_elasticsearch_index_params
 
 
 def elasticsearch_query_parsing_exception_handler(error):
@@ -594,6 +594,8 @@ class RecordsListResource(ContentNegotiatedMethodView):
         if permission_factory:
             verify_record_permission(permission_factory, data)
 
+        urlkwargs = parse_elasticsearch_index_params(request.values)
+
         # Create uuid for record
         record_uuid = uuid.uuid4()
         # Create persistent identifier
@@ -605,7 +607,7 @@ class RecordsListResource(ContentNegotiatedMethodView):
 
         # Index the record
         if self.indexer_class:
-            self.indexer_class().index(record)
+            self.indexer_class().index(record, **urlkwargs)
 
         response = self.make_response(
             pid, record, 201, links_factory=self.item_links_factory)


### PR DESCRIPTION
Fixes https://github.com/inveniosoftware/invenio-records-files/issues/53 (Probably worth it to change or duplicate the issue here).

It allows binary files content extraction by using Elasticsearch attachment pipeline. In order to do so, it has to send the parameter ``pipeline`` with a value equals to the pipeline id (ej. ``attachment``).

Needs: https://github.com/inveniosoftware/invenio-indexer/pull/99.
