### PR TITLE
config: addition of configurable search results size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.4.1 (released 2019-04-02)
+
+- Added ``RECORDS_REST_DEFAULT_RESULTS_SIZE`` variable to change the default
+  ``size`` of the search results. The default value remains ``10``.
+
 Version 1.4.0 (released 2019-02-22)
 
 - Removed unused resolver parameter from views classes.

--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -363,3 +363,6 @@ RECORDS_REST_ELASTICSEARCH_ERROR_HANDLERS = {
     ),
 }
 """Handlers for ElasticSearch error codes."""
+
+RECORDS_REST_DEFAULT_RESULTS_SIZE = 10
+"""Default search results size."""

--- a/invenio_records_rest/loaders/__init__.py
+++ b/invenio_records_rest/loaders/__init__.py
@@ -8,8 +8,8 @@
 
 """Loaders for deserializing records in the REST API."""
 
+from ..schemas import RecordMetadataSchemaJSONV1, RecordSchemaJSONV1
 from .marshmallow import json_patch_loader, marshmallow_loader
-from ..schemas import RecordSchemaJSONV1, RecordMetadataSchemaJSONV1
 
 json_v1 = marshmallow_loader(RecordSchemaJSONV1)
 """Simple example loader that will take any JSON."""

--- a/invenio_records_rest/schemas/__init__.py
+++ b/invenio_records_rest/schemas/__init__.py
@@ -10,7 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
-from .json import Nested, RecordSchemaJSONV1, StrictKeysMixin, RecordMetadataSchemaJSONV1
+from .json import Nested, RecordMetadataSchemaJSONV1, RecordSchemaJSONV1, \
+    StrictKeysMixin
 
 __all__ = (
     'RecordSchemaJSONV1',

--- a/invenio_records_rest/serializers/__init__.py
+++ b/invenio_records_rest/serializers/__init__.py
@@ -10,9 +10,9 @@
 
 from __future__ import absolute_import, print_function
 
+from ..schemas import RecordSchemaJSONV1
 from .json import JSONSerializer
 from .response import record_responsify, search_responsify
-from ..schemas import RecordSchemaJSONV1
 
 json_v1 = JSONSerializer(RecordSchemaJSONV1)
 """JSON v1 serializer."""

--- a/invenio_records_rest/version.py
+++ b/invenio_records_rest/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -512,8 +512,10 @@ class RecordsListResource(ContentNegotiatedMethodView):
         :returns: Search result containing hits and aggregations as
                   returned by invenio-search.
         """
+        default_results_size = current_app.config.get(
+            'RECORDS_REST_DEFAULT_RESULTS_SIZE', 10)
         page = request.values.get('page', 1, type=int)
-        size = request.values.get('size', 10, type=int)
+        size = request.values.get('size', default_results_size, type=int)
         if page * size >= self.max_result_window:
             raise MaxResultWindowRESTError()
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup_requires = [
 
 install_requires = [
     'arrow>=0.12.1',
+    'attrs>=17.4.0',
     'bleach>=2.1.3',
     'ftfy>=4.4.3,<5.0',
     'Flask>=0.11.1',
@@ -84,7 +85,7 @@ install_requires = [
     'invenio-indexer>=1.0.0',
     'marshmallow>=2.5.0',
     'python-dateutil>=2.4.2',
-    'six>=1.10',
+    'six>=1.11',
     'webargs>=1.3.2',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,7 @@ def app(request, search_class):
         RECORDS_REST_DEFAULT_DELETE_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_READ_PERMISSION_FACTORY=None,
         RECORDS_REST_DEFAULT_UPDATE_PERMISSION_FACTORY=None,
+        RECORDS_REST_DEFAULT_RESULTS_SIZE=10,
         RECORDS_REST_DEFAULT_SEARCH_INDEX=search_class.Meta.index,
         RECORDS_REST_FACETS={
             search_class.Meta.index: {


### PR DESCRIPTION
* Adds ``RECORDS_REST_DEFAULT_SEARCH_RESULTS_SIZE``
  variable to change the default ``size`` of the search results.
  The default value remains ``10``.

Signed-off-by: Harris Tzovanakis <me@drjova.com>