### PR TITLE
marshamllow: use getfullargspec instead getargspec in python3

### DIFF
--- a/invenio_records_rest/schemas/fields/marshmallow_contrib.py
+++ b/invenio_records_rest/schemas/fields/marshmallow_contrib.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2018 CERN.
+# Copyright (C) 2018-2019 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,19 +11,25 @@
 from __future__ import absolute_import, print_function
 
 import functools
-import inspect
+from inspect import isfunction, ismethod
 
 from marshmallow import fields, utils
+
+# Recommended way of maintaining compatibility with python 2 for getargspec
+try:
+    from inspect import getfullargspec as getargspec
+except ImportError:
+    from inspect import getargspec
 
 
 def _get_func_args(func):
     """Get a list of the arguments a function or method has."""
     if isinstance(func, functools.partial):
         return _get_func_args(func.func)
-    if inspect.isfunction(func) or inspect.ismethod(func):
-        return list(inspect.getargspec(func).args)
+    if isfunction(func) or ismethod(func):
+        return list(getargspec(func).args)
     if callable(func):
-        return list(inspect.getargspec(func.__call__).args)
+        return list(getargspec(func.__call__).args)
 
 
 class Function(fields.Function):

--- a/tests/test_marshmallow_contrib.py
+++ b/tests/test_marshmallow_contrib.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2019 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""Invenio marshmallow contrib tests."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_records_rest.schemas.fields.marshmallow_contrib import \
+    _get_func_args
+
+
+def test_get_func_args_on_func():
+    def test_function(arg1, arg2, arg3=None, arg4=None):
+        pass
+
+    expected_args = ['arg1', 'arg2', 'arg3', 'arg4']
+    assert _get_func_args(test_function) == expected_args
+
+
+def test_get_func_args_on_method():
+    class test_class():
+        def test_method(self, arg1, arg2, arg3):
+            pass
+
+    expected_args = ['self', 'arg1', 'arg2', 'arg3']
+    assert _get_func_args(test_class().test_method) == expected_args
+
+
+def test_get_func_args_on_callable():
+    class test_callable():
+        def __call__(self, arg1, arg2, arg3):
+            pass
+
+    expected_args = ['self', 'arg1', 'arg2', 'arg3']
+    assert _get_func_args(test_callable) == expected_args


### PR DESCRIPTION
closes #251 