### PR TITLE
REVIEW NEEDED [WIP] global: add vary header to the response

### DIFF
--- a/invenio_records_rest/serializers/response.py
+++ b/invenio_records_rest/serializers/response.py
@@ -30,6 +30,7 @@ def record_responsify(serializer, mimetype):
         response.status_code = code
         response.set_etag(str(record.revision_id))
         response.last_modified = record.updated
+        response.vary = 'Content-Type, Accept'
         if headers is not None:
             response.headers.extend(headers)
 

--- a/invenio_records_rest/serializers/response.py
+++ b/invenio_records_rest/serializers/response.py
@@ -14,6 +14,7 @@ Responsible for creating a HTTP response given the output of a serializer.
 from __future__ import absolute_import, print_function
 
 from flask import current_app
+from invenio_rest.views import create_etag
 
 
 def record_responsify(serializer, mimetype):
@@ -28,7 +29,7 @@ def record_responsify(serializer, mimetype):
             serializer.serialize(pid, record, links_factory=links_factory),
             mimetype=mimetype)
         response.status_code = code
-        response.set_etag(str(record.revision_id))
+        response.set_etag(create_etag(record.revision_id, mimetype))
         response.last_modified = record.updated
         response.vary = 'Content-Type, Accept'
         if headers is not None:
@@ -39,6 +40,7 @@ def record_responsify(serializer, mimetype):
 
         return response
 
+    view.mimetype = mimetype
     return view
 
 

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -28,6 +28,7 @@ from invenio_pidstore.models import PersistentIdentifier
 from invenio_records.api import Record
 from invenio_rest import ContentNegotiatedMethodView
 from invenio_rest.decorators import require_content_types
+from invenio_rest.views import create_etag
 from invenio_search import RecordsSearch
 from jsonpatch import JsonPatchException, JsonPointerException
 from jsonschema.exceptions import ValidationError
@@ -800,12 +801,16 @@ class RecordResource(ContentNegotiatedMethodView):
         :param record: Record object.
         :returns: The requested record.
         """
-        etag = str(record.revision_id)
-        self.check_etag(str(record.revision_id))
+        serializer = self.find_method_serializer()
+
+        etag = create_etag(record.revision_id, serializer.mimetype)
+        self.check_etag(etag)
         self.check_if_modified_since(record.updated, etag=etag)
 
         return self.make_response(
-            pid, record, links_factory=self.links_factory
+            pid, record,
+            links_factory=self.links_factory,
+            serializer=serializer
         )
 
     @require_content_types('application/json-patch+json')

--- a/tests/test_views_item_get.py
+++ b/tests/test_views_item_get.py
@@ -14,6 +14,8 @@ import pytest
 from flask import url_for
 from helpers import get_json, record_url, to_relative_url
 
+from invenio_rest.views import create_etag
+
 
 def test_item_get(app, test_records):
     """Test record retrieval."""
@@ -21,8 +23,9 @@ def test_item_get(app, test_records):
         pid, record = test_records[0]
 
         res = client.get(record_url(pid))
+        expected_etag = create_etag(record.revision_id, "application/json")
         assert res.status_code == 200
-        assert res.headers['ETag'] == '"{}"'.format(record.revision_id)
+        assert res.headers['ETag'] == '"{}"'.format(expected_etag)
 
         # Check metadata
         data = get_json(res)


### PR DESCRIPTION
FOR THE REVIEWERS: this is a proposal of the solution, it will be applied not only for the get method but please first share your thoughts

( addresses #250)

**Update:**
The main issue seemed to be that the vary header had no effect if the `etag` was unchanged so the new WIP version has the `etag` include not only the `record.revision_id` but also the mimetype. It's still unclear which effect the `Vary` header has but without it sometimes it doesn't recognize if a change is made in the `Accept` header so it seems to be needed.

Requires https://github.com/inveniosoftware/invenio-rest/pull/100


**PAST NOTES ON THE ISSUE:**

THIS IS not working fully - below my investigation
How to test:
1. Create clean instance
2. Install latest invenio 3.2.0a5
3. install invenio-records-rest from this PR
3.1. on your clean instance create custom serializer of the record f.e. application/x-custom mimetype - make sure it returns also this content type as a response example: https://github.com/kprzerwa/test-headers-instance/blob/master/my_site/records/config.py

You can use firefox for debugging - it has neat way of editing headers in the dev tools

4. post a new record
5. go to `/records/1`
6. response should have `Vary: Content-Type, Accept` header - check this PR
7. Hit again the same endpoint - the response should be cached. But it will not have the Vary header anymore! <--- I think this is where the problem is located
8. change the Accept header to your custom `application/x-custom` in the request and request again the endpoint. You will get the same json response, cached, while you should get 200 status code response with x-custom content type. 
What is probably the problem here: The cached response is not adding the Vary header so the browser does not know that it should check the Accept value every time, and relies only on the combination of `ETag` (which is version of the record) passed to `If-None-Match` header and `If-Modified-Since` header which won't change in this case.  

