### PR TITLE
views: fix wrong `size` param upper limit

### DIFF
--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -501,7 +501,7 @@ def use_paginate_args(default_size=25, max_results=10000):
                     )
                 ))
 
-            if req['to_idx'] >= _max_results:
+            if req['to_idx'] > _max_results:
                 raise SearchPaginationRESTError(
                     description=(
                         'Maximum number of {} results have been reached.'


### PR DESCRIPTION
* Since the `size` url param is internally passed to the ES
  query as Python list[start:size], its upper limit value should be
  equal to `max_result_window`