### PR TITLE
global: manage flask dependency centrally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
-dist: trusty
 
 addons:
   postgresql: 9.4
+  apt:
+    packages:
+      - rabbitmq-server
 
 notifications:
   email: false
-
-sudo: false
 
 language: python
 
@@ -27,7 +27,6 @@ cache:
 
 services:
   - postgresql
-  - rabbitmq
   - redis
 
 env:
@@ -46,10 +45,11 @@ env:
 
 
 python:
-  - "2.7"
-  - "3.5"
+  - "3.6"
+  - "3.7"
 
 before_install:
+  - "pip uninstall -y six"
   - "mkdir /tmp/elasticsearch"
   - "wget -O - $ES_URL | tar xz --directory=/tmp/elasticsearch --strip-components=1"
   - "/tmp/elasticsearch/bin/elasticsearch > /tmp/local-es.log &"
@@ -81,8 +81,9 @@ deploy:
   password:
     secure: "EYDHlsJ2JLUuO4bqre5bLliHO3ga/c5gBnIMyyFTMXEjxmRpvZ9JkCYkCEtwD5OIBXEplRdLv19Q2E+yfUDtBtN/BPALiGoHnkH78IfLab0ZmlFYESinI4ChwluS++uYi8dijdzwfVQyjTcrQzwpfHiU8wcUZdX0zBr+G1Zlk7MQWIN03cvlAi0Qxoevj/SJB5aL3q2sw+fjP+zLFap0b94q3lWLLAB3Oivtd7ujMTbRzaFW7XB8pcop7rMTrw7+A3/5bmzvZ4uc82VY44XNEP5/Fb0+jSx5l6c9ndXBQXVeHNgQrxbluaMqISmPhsUug4BfoRpabn9tD5xjjqaXrdZGo6cP0xCzGJJdv205IeJu7cV74A6B2O5pNSpZEu/Hn2aq0BYaYn3TDJ5UbO4rGprH8jqZwhSzL5fQvHeULzTLJfTWw07O9KXapQME9kx1qmZycqj+CA81MeYR1AeoERk9smB+k3Pv9IcFQPvMsgRyB0LhIi8bcygc1BGPWRTA1Qbk2p8/xdqgLjMRy2rsDA/+x3ftflBp0CwFU/UoTVEfGOx+mEapyGw8Tx0pijyU+r1t7jgNWnqEupVlHQq4wof4DFZYFAVuWk24SrHiwuaXS+l+uXtusvBodBa3NWfYdfZyASqREAvnRSIkTfF7J/0DpEkWDLiDU8AhgutvLno="
   distributions: "compile_catalog sdist bdist_wheel"
+  skip_existing: true
   on:
     tags: true
-    python: "3.5"
+    python: "3.6"
     repo: inveniosoftware/invenio-records-rest
     condition: $DEPLOY = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.7.0 (released 2020-03-13)
+
+- Removes support for python 2.7
+- Centralises management of Flask dependency by invenio-base
+
 Version 1.6.4 (released 2019-12-11)
 
 - Fixes loaders error payload to add support for nested fields

--- a/invenio_records_rest/version.py
+++ b/invenio_records_rest/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.6.4'
+__version__ = '1.7.0'

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -13,3 +13,4 @@
 -e git+git://github.com/inveniosoftware/invenio-records.git#egg=invenio-records
 -e git+git://github.com/inveniosoftware/invenio-rest.git#egg=invenio-rest
 -e git+git://github.com/inveniosoftware/invenio-search.git#egg=invenio-search
+-e git+https://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -81,14 +81,13 @@ install_requires = [
     'attrs>=17.4.0',
     'bleach>=2.1.3',
     'ftfy>=4.4.3,<5.0',
-    'Flask>=0.11.1',
-    'Flask-BabelEx>=0.9.2',
-    'invenio-pidstore>=1.0.0',
+    'invenio-base>=1.2.2',
+    'invenio-pidstore>=1.2.0',
     'invenio-records>=1.0.0',
-    'invenio-rest>=1.1.2',
+    'invenio-rest>=1.2.0',
     'invenio-indexer>=1.1.0',
+    'invenio-i18n>=1.2.0',
     'python-dateutil>=2.4.2',
-    'six>=1.12',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* update travis.yml
* drop support for Python 2.7
* closes #289 