### PR TITLE
fields: add __bool__ for GenFunction

### DIFF
--- a/invenio_records_rest/schemas/fields/generated.py
+++ b/invenio_records_rest/schemas/fields/generated.py
@@ -21,7 +21,11 @@ from .marshmallow_contrib import Function, Method
 class GeneratedValue(object):
     """Sentinel value class forcing marshmallow missing field generation."""
 
-    pass
+    def __bool__(self):
+        """Override bool()."""
+        return False
+
+    __nonzero__ = __bool__
 
 
 class ForcedFieldDeserializeMixin(object):


### PR DESCRIPTION
* Adds a __bool__ (and __nonzero__ for compatibility) method to the
  GeneratedValue class, to mimic marshmallow's "missing" behavior.