### PR TITLE
views: fix local variable 'pid' referenced before assignment

### DIFF
--- a/invenio_records_rest/errors.py
+++ b/invenio_records_rest/errors.py
@@ -203,3 +203,11 @@ class UnhandledElasticsearchError(RESTException):
     code = 500
     description = 'An internal server error occurred when handling the ' \
                   'request.'
+
+
+class DatabaseErrorRESTError(RESTException):
+    """Database general exception."""
+
+    code = 500
+    description = 'An internal server error occurred when handling the ' \
+                  'request.'

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -38,9 +38,9 @@ from webargs.flaskparser import parser
 from werkzeug.exceptions import BadRequest
 
 from ._compat import wrap_links_factory
-from .errors import InvalidDataRESTError, InvalidQueryRESTError, \
-    JSONSchemaValidationError, PatchJSONFailureRESTError, \
-    PIDResolveRESTError, SearchPaginationRESTError, \
+from .errors import DatabaseErrorRESTError, InvalidDataRESTError, \
+    InvalidQueryRESTError, JSONSchemaValidationError, \
+    PatchJSONFailureRESTError, SearchPaginationRESTError, \
     SuggestMissingContextRESTError, SuggestNoCompletionsRESTError, \
     UnhandledElasticsearchError, UnsupportedMediaRESTError
 from .links import default_links_factory
@@ -383,7 +383,7 @@ def pass_record(f):
             pid, record = request.view_args['pid_value'].data
             return f(self, pid=pid, record=record, *args, **kwargs)
         except SQLAlchemyError:
-            raise PIDResolveRESTError(pid)
+            raise DatabaseErrorRESTError()
 
     return inner
 


### PR DESCRIPTION
pid variable does not exist as SQLAlchemyError can happen only during pid variable assignment so it shouldn't be used when handling this exception.
* INSPIR-3282