### PR TITLE
utils: make PID converter lazier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ env:
     - ES_HOST=127.0.0.1
     - SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
   matrix:
-    - REQUIREMENTS=lowest EXTRAS=all,elasticsearch5 ES_URL=$ES5_DOWNLOAD_URL
-    - REQUIREMENTS=lowest EXTRAS=all,elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
-    - REQUIREMENTS=release EXTRAS=all,elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
-    - REQUIREMENTS=release EXTRAS=all,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL DEPLOY=true
-    - REQUIREMENTS=devel EXTRAS=all,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
+    - REQUIREMENTS=lowest EXTRAS=elasticsearch5 ES_URL=$ES5_DOWNLOAD_URL
+    - REQUIREMENTS=lowest EXTRAS=elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
+    - REQUIREMENTS=release EXTRAS=elasticsearch6 ES_URL=$ES6_DOWNLOAD_URL
+    - REQUIREMENTS=release EXTRAS=elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL DEPLOY=true
+    - REQUIREMENTS=devel EXTRAS=elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
 
 
 python:
@@ -63,7 +63,7 @@ before_install:
 
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
-  - "travis_retry pip install -e .[$EXTRAS]"
+  - "travis_retry pip install -e .[all,$EXTRAS]"
   - "pip freeze"
 
 before_script:

--- a/invenio_records_rest/_compat.py
+++ b/invenio_records_rest/_compat.py
@@ -9,7 +9,7 @@
 """Python 2/3 compatibility helpers."""
 
 try:  # Python 3 way of inspecting functions
-    from inspect import signature, Parameter
+    from inspect import Parameter, signature
 
     def wrap_links_factory(links_factory):
         """Test if the links_factory function accepts kwargs."""

--- a/invenio_records_rest/utils.py
+++ b/invenio_records_rest/utils.py
@@ -206,12 +206,23 @@ class PIDConverter(BaseConverter):
                  object_type='rec'):
         """Initialize the converter."""
         super(PIDConverter, self).__init__(url_map)
-        getter = obj_or_import_string(getter, default=partial(
-            obj_or_import_string(record_class, default=Record).get_record,
-            with_deleted=True
-        ))
-        self.resolver = Resolver(pid_type=pid_type, object_type=object_type,
-                                 getter=getter)
+        self.pid_type = pid_type
+        self.getter = getter
+        self.record_class = record_class
+        self.object_type = object_type
+
+    @cached_property
+    def resolver(self):
+        """PID resolver."""
+        record_cls = obj_or_import_string(self.record_class, default=Record)
+        getter = obj_or_import_string(
+            self.getter,
+            default=partial(record_cls.get_record, with_deleted=True))
+        return Resolver(
+            pid_type=self.pid_type,
+            object_type=self.object_type,
+            getter=getter
+        )
 
     def to_python(self, value):
         """Resolve PID value."""

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -383,8 +383,7 @@ def pass_record(f):
             pid, record = request.view_args['pid_value'].data
             return f(self, pid=pid, record=record, *args, **kwargs)
         except SQLAlchemyError:
-            raise PIDResolveRESTError(pid)
-
+            raise PIDResolveRESTError(pid_value)
     return inner
 
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,4 +11,4 @@ pydocstyle invenio_records_rest tests docs && \
 isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test
+py.test

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,7 +8,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 pydocstyle invenio_records_rest tests docs && \
-isort -rc -c -df && \
+isort invenio_records_rest tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 py.test


### PR DESCRIPTION
* Makes the PIDConverter lazier in terms of initializing its "resolver"
  class member, which allows e.g. passing a "record_class" that might
  depend on application context being loaded.