### PR TITLE
Marshmallow Errors: flask 2 compatibility change

### DIFF
--- a/invenio_records_rest/loaders/marshmallow.py
+++ b/invenio_records_rest/loaders/marshmallow.py
@@ -75,7 +75,7 @@ class MarshmallowErrors(RESTValidationError):
         """Get next file item."""
         return next(self._it)
 
-    def get_body(self, environ=None):
+    def get_body(self, environ=None, scope=None):
         """Get the request body."""
         body = dict(
             status=self.code,


### PR DESCRIPTION
Changed the params of the get_body function to accommodate for the "scope" positional argument needed in newer releases of werkzeug