### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 2.2.0 (2023-03-03)
+
+- remove deprecated flask-babelex dependency and imports
+- upgrade invenio-i18n
+
 Version 2.1.0 (2022-10-03)
 
 - Add support to OpenSearch v2

--- a/invenio_records_rest/__init__.py
+++ b/invenio_records_rest/__init__.py
@@ -711,6 +711,6 @@ by Invenio-PIDStore.
 from .ext import InvenioRecordsREST
 from .proxies import current_records_rest
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 __all__ = ("__version__", "current_records_rest", "InvenioRecordsREST")

--- a/invenio_records_rest/facets.py
+++ b/invenio_records_rest/facets.py
@@ -60,10 +60,9 @@ def range_filter(field, start_date_math=None, end_date_math=None, **kwargs):
         date_maths = [start_date_math, end_date_math]
 
         # Add the proper values to the dict
-        for (range_end, strict, opers, date_math) in zip(
+        for range_end, strict, opers, date_math in zip(
             range_ends, [">", "<"], ineq_opers, date_maths
         ):
-
             if range_end != "":
                 # If first char is '>' for start or '<' for end
                 if range_end[0] == strict:

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2019 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -23,8 +24,8 @@ from flask import (
     url_for,
 )
 from flask.views import MethodView
-from flask_babelex import gettext as _
 from invenio_db import db
+from invenio_i18n import gettext as _
 from invenio_indexer.api import RecordIndexer
 from invenio_pidstore import current_pidstore
 from invenio_pidstore.models import PersistentIdentifier
@@ -445,7 +446,6 @@ def use_paginate_args(default_size=25, max_results=10000):
     def decorator(f):
         @wraps(f)
         def inner(self, *args, **kwargs):
-
             _default_size = (
                 default_size(self) if callable(default_size) else default_size
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     invenio-records>=2.0.0,<3.0.0
     invenio-rest>=1.2.4,<2.0.0
     invenio-indexer>=2.1.0,<3.0.0
-    invenio-i18n>=1.3.0,<2.0.0
+    invenio-i18n>=2.0.0,<3.0.0
 
 [options.extras_require]
 tests =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from helpers import create_record
 from invenio_config import InvenioConfigDefault
 from invenio_db import InvenioDB
 from invenio_db import db as db_
+from invenio_i18n import InvenioI18N
 from invenio_indexer import InvenioIndexer
 from invenio_indexer.api import RecordIndexer
 from invenio_indexer.signals import before_record_index
@@ -183,6 +184,7 @@ def app(request, search_class):
     InvenioIndexer(app)
     InvenioPIDStore(app)
     InvenioConfigDefault(app)
+    InvenioI18N(app)
     search = InvenioSearch(app)
     search.register_mappings(search_class.Meta.index, "mock_module.mappings")
     InvenioRecordsREST(app)

--- a/tests/test_custom_endpoints.py
+++ b/tests/test_custom_endpoints.py
@@ -34,6 +34,7 @@ from invenio_records_rest.views import RecordResource, RecordsListResource
 @pytest.fixture()
 def test_custom_endpoints_app(app):
     """Create an application enabling the creation of a custom endpoint."""
+
     # Hack necessary to have links generated properly
     @app.before_first_request
     def extend_default_endpoint_prefixes():

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -77,8 +77,8 @@ def test_custom_error_handlers(app, db, test_data):
         data = json.loads(res.get_data(as_text=True))
         assert data == {
             "message": (
-                "The browser (or proxy) sent a request that this server could "
-                "not understand."
+                "Failed to decode JSON object: Expecting property name "
+                "enclosed in double quotes: line 1 column 2 (char 1)"
             ),
             "status": 400,
         }

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -77,8 +77,8 @@ def test_custom_error_handlers(app, db, test_data):
         data = json.loads(res.get_data(as_text=True))
         assert data == {
             "message": (
-                "Failed to decode JSON object: Expecting property name "
-                "enclosed in double quotes: line 1 column 2 (char 1)"
+                "The browser (or proxy) sent a request that this server could "
+                "not understand."
             ),
             "status": 400,
         }

--- a/tests/test_views_search.py
+++ b/tests/test_views_search.py
@@ -345,7 +345,9 @@ def test_from_parameter_invalid_pagination(app, indexed_records, search_url):
         assert res.status_code == 400
         assert data["message"] == "Invalid pagination parameters."
         errors = {(e["field"], e["message"]) for e in data["errors"]}
-        assert errors == {("from", "Must be at least 1."),} or errors == {
+        assert errors == {
+            ("from", "Must be at least 1."),
+        } or errors == {
             ("from", "Must be greater than or equal to 1."),
         }
 


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- fix: black due new black version
- fix: tests

- NOTE: invenio-i18n, invenio-pidstore, invenio-records have to be released before
