### PR TITLE
facets: Create a new filter for nested filters

### DIFF
--- a/invenio_records_rest/facets.py
+++ b/invenio_records_rest/facets.py
@@ -21,6 +21,24 @@ from werkzeug.datastructures import MultiDict
 from invenio_records_rest.utils import make_comma_list_a_list
 
 
+def nested_filter(field, url_subfield, subfield):
+    """Create a nested filter. Similar to the https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/services/records/facets/facets.py#L94"""
+
+    def inner(values):
+        subvalues = request.values.getlist(url_subfield, type=text_type)
+        if subvalues:
+            return dsl.Q(
+                "bool",
+                should=[
+                    dsl.Q("terms", **{field: values}),
+                    dsl.Q("terms", **{subfield: subvalues}),
+                ],
+            )
+        return dsl.Q("terms", **{field: values})
+
+    return inner
+
+
 def terms_filter(field):
     """Create a term filter.
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

New filter for fields used in nested facets. Example:
* Imagine a filter by type of file (Documentation, Dataset, Environment, ...) and the types could have subtypes (Documentation has About, Guide, Help, ...)
* This filter will give things like: 
   * all Documentation or Dataset
   * Documentation::About or Dataset
   * Documentation::About or Dataset::Simulated

Note that there are issues if the name of the subtype appears in multiple categories.