### PR TITLE
facets: New parameter, RECORDS_REST_FACETS_FILTER, to filter the face…

### DIFF
--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -344,6 +344,9 @@ The structure of the dictionary is as follows:
     }
 """
 
+RECORDS_REST_FACETS_POST_FILTERS_PROPAGATE = False
+"""Define if the post_filters facets in one category should be applied as filters to all the other categories"""
+
 RECORDS_REST_DEFAULT_CREATE_PERMISSION_FACTORY = deny_all
 """Default create permission factory: reject any request."""
 


### PR DESCRIPTION
…ts based on a category based on all the other categories

:heart: Thank you for your contribution!

### Description

This is inspired by the work of @ParthS007  [here](https://github.com/cernopendata/opendata.cern.ch/commit/4cd8bd186d04286aaedbc8a09ccd4938bc96d98d)

The idea is to offer the possibility to apply the filters to the aggregations. As an example:
* Imagine a search with two different categories,  `cat1`  and `cat2`.
* The user selects `cat1=value1`
* The current options are that either that selection is applied to the results, and the aggregation (standard filter), or only to the results (`post_filter`). 
* This PR introduces a new option, where the filter is applied to the results, and to all the other aggregations (in the example, the aggregation of `cat2` will return only the entrie that satisfy `cat1=value1`, but the aggregation for `cat1` returns everything.
