### PR TITLE
facet: Allow more than one possibility on range facets.

### DIFF
--- a/invenio_records_rest/facets.py
+++ b/invenio_records_rest/facets.py
@@ -79,41 +79,47 @@ def range_filter(field, start_date_math=None, end_date_math=None, **kwargs):
     """
 
     def inner(values):
-        if len(values) != 1 or values[0].count("--") != 1 or values[0] == "--":
-            raise RESTValidationError(
-                errors=[FieldError(field, "Invalid range format.")]
-            )
+        queries = []
+        for value in values:
+            if value.count("--") != 1 or value == "--":
+                raise RESTValidationError(
+                    errors=[FieldError(field, "Invalid range format.")]
+                )
 
-        range_ends = values[0].split("--")
-        range_args = dict()
+            range_ends = value.split("--")
+            range_args = dict()
 
-        ineq_opers = [
-            {"strict": "gt", "nonstrict": "gte"},
-            {"strict": "lt", "nonstrict": "lte"},
-        ]
-        date_maths = [start_date_math, end_date_math]
+            ineq_opers = [
+                {"strict": "gt", "nonstrict": "gte"},
+                {"strict": "lt", "nonstrict": "lte"},
+            ]
+            date_maths = [start_date_math, end_date_math]
 
-        # Add the proper values to the dict
-        for range_end, strict, opers, date_math in zip(
-            range_ends, [">", "<"], ineq_opers, date_maths
-        ):
-            if range_end != "":
-                # If first char is '>' for start or '<' for end
-                if range_end[0] == strict:
-                    dict_key = opers["strict"]
-                    range_end = range_end[1:]
-                else:
-                    dict_key = opers["nonstrict"]
+            # Add the proper values to the dict
+            for range_end, strict, opers, date_math in zip(
+                range_ends, [">", "<"], ineq_opers, date_maths
+            ):
+                if range_end != "":
+                    # If first char is '>' for start or '<' for end
+                    if range_end[0] == strict:
+                        dict_key = opers["strict"]
+                        range_end = range_end[1:]
+                    else:
+                        dict_key = opers["nonstrict"]
 
-                if date_math:
-                    range_end = "{0}||{1}".format(range_end, date_math)
+                    if date_math:
+                        range_end = "{0}||{1}".format(range_end, date_math)
 
-                range_args[dict_key] = range_end
+                    range_args[dict_key] = range_end
 
-        args = kwargs.copy()
-        args.update(range_args)
+            args = kwargs.copy()
+            args.update(range_args)
 
-        return dsl.query.Range(**{field: args})
+            queries.append(dsl.query.Range(**{field: args}))
+
+        if len(queries) > 1:
+            return dsl.Q("bool", should=queries)
+        return queries[0]
 
     return inner
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Range queries currently allow only one possible selection. Check for instance on opendata.cern.ch, where the `Event number` is a range:

![Screenshot 2023-12-07 at 18 29 01](https://github.com/inveniosoftware/invenio-records-rest/assets/12909623/a5e80f72-ac75-49d5-b9e4-901892fe1233)
![Screenshot 2023-12-07 at 18 28 22](https://github.com/inveniosoftware/invenio-records-rest/assets/12909623/11a6605a-fb67-4e70-8155-d41bb7551af7)


This merge request allows multiple ranges to be selected, and they will be combined into a boolean query

