### PR TITLE
marshmallow: remove deprecation warning

### DIFF
--- a/invenio_records_rest/loaders/marshmallow.py
+++ b/invenio_records_rest/loaders/marshmallow.py
@@ -18,7 +18,8 @@ import json
 from flask import request
 from invenio_rest.errors import RESTValidationError
 from marshmallow import ValidationError
-from marshmallow import __version_info__ as marshmallow_version
+
+from ..utils import marshmallow_major_version
 
 
 def _flatten_marshmallow_errors(errors, parents=()):
@@ -81,7 +82,7 @@ def marshmallow_loader(schema_class):
             pid, record = pid_data.data
             context["pid"] = pid
             context["record"] = record
-        if marshmallow_version[0] < 3:
+        if marshmallow_major_version < 3:
             result = schema_class(context=context).load(request_json)
             if result.errors:
                 raise MarshmallowErrors(result.errors)

--- a/invenio_records_rest/schemas/fields/generated.py
+++ b/invenio_records_rest/schemas/fields/generated.py
@@ -10,8 +10,9 @@
 
 import warnings
 
-from marshmallow import __version_info__ as marshmallow_version
 from marshmallow import missing as missing_
+
+from invenio_records_rest.utils import marshmallow_major_version
 
 from .marshmallow_contrib import Function, Method
 
@@ -25,7 +26,7 @@ class GeneratedValue(object):
 class ForcedFieldDeserializeMixin(object):
     """Mixin that forces deserialization of marshmallow fields."""
 
-    if marshmallow_version[0] < 3:
+    if marshmallow_major_version < 3:
 
         def __init__(self, *args, **kwargs):
             """Override the "missing" parameter."""

--- a/invenio_records_rest/schemas/json.py
+++ b/invenio_records_rest/schemas/json.py
@@ -10,11 +10,11 @@
 
 from flask import current_app
 from invenio_rest.serializer import BaseSchema as Schema
-from marshmallow import ValidationError
-from marshmallow import __version_info__ as marshmallow_version
-from marshmallow import fields, missing, post_load, validates_schema
+from marshmallow import ValidationError, fields, missing, post_load, validates_schema
 
 from invenio_records_rest.schemas.fields import PersistentIdentifier
+
+from ..utils import marshmallow_major_version
 
 
 class StrictKeysMixin(Schema):
@@ -74,7 +74,7 @@ class OriginalKeysMixin(Schema):
         return data
 
 
-if marshmallow_version[0] < 3:
+if marshmallow_major_version < 3:
 
     class RecordMetadataSchemaJSONV1(OriginalKeysMixin):
         """Schema for records metadata v1 in JSON with injected PID value."""

--- a/invenio_records_rest/utils.py
+++ b/invenio_records_rest/utils.py
@@ -10,6 +10,7 @@
 
 from functools import partial
 
+import pkg_resources
 import six
 from flask import abort, current_app, jsonify, make_response, request, url_for
 from invenio_pidstore.errors import (
@@ -32,6 +33,10 @@ from .errors import (
     PIDUnregisteredRESTError,
 )
 from .proxies import current_records_rest
+
+marshmallow_major_version = int(
+    pkg_resources.get_distribution("marshmallow").version[0]
+)
 
 
 def build_default_endpoint_prefixes(records_rest_endpoints):

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -12,7 +12,6 @@ import pytest
 from invenio_pidstore.models import PersistentIdentifier as PIDModel
 from invenio_records import Record
 from invenio_rest.serializer import BaseSchema as Schema
-from marshmallow import __version_info__ as marshmallow_version
 from marshmallow import missing
 
 from invenio_records_rest.schemas import StrictKeysMixin
@@ -25,8 +24,9 @@ from invenio_records_rest.schemas.fields import (
     SanitizedUnicode,
     TrimmedString,
 )
+from invenio_records_rest.utils import marshmallow_major_version
 
-if marshmallow_version[0] >= 3:
+if marshmallow_major_version >= 3:
     schema_to_use = Schema
     from marshmallow import EXCLUDE
 else:
@@ -36,7 +36,7 @@ else:
 class CustomFieldSchema(schema_to_use):
     """Test schema."""
 
-    if marshmallow_version[0] >= 3:
+    if marshmallow_major_version >= 3:
 
         class Meta:
             """."""
@@ -107,7 +107,7 @@ def test_custom_generated_fields():
     class GeneratedFieldsSchema(schema_to_use):
         """Test schema."""
 
-        if marshmallow_version[0] >= 3:
+        if marshmallow_major_version >= 3:
 
             class Meta:
                 """Meta attributes for the schema."""

--- a/tests/test_marshmallow_loader.py
+++ b/tests/test_marshmallow_loader.py
@@ -14,9 +14,7 @@ from copy import deepcopy
 from helpers import get_json
 from invenio_records.models import RecordMetadata
 from invenio_rest.serializer import BaseSchema as Schema
-from marshmallow import ValidationError
-from marshmallow import __version_info__ as marshmallow_version
-from marshmallow import fields
+from marshmallow import ValidationError, fields
 
 from invenio_records_rest.loaders import json_pid_checker
 from invenio_records_rest.loaders.marshmallow import (
@@ -25,6 +23,7 @@ from invenio_records_rest.loaders.marshmallow import (
 )
 from invenio_records_rest.schemas import Nested
 from invenio_records_rest.schemas.fields import PersistentIdentifier
+from invenio_records_rest.utils import marshmallow_major_version
 
 
 class _TestSchema(Schema):
@@ -166,7 +165,7 @@ def test_marshmallow_load_nested_subfield_errors(
 def test_marshmallow_errors(test_data):
     """Test MarshmallowErrors class."""
     incomplete_data = dict(test_data[0])
-    if marshmallow_version[0] >= 3:
+    if marshmallow_major_version >= 3:
         try:
             res = _TestSchema(context={}).load(json.dumps(incomplete_data))
         except ValidationError as error:


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Remove deprecation warnings from marshmallow, like:
```
/opt/invenio/var/instance/python/lib/python3.9/site-packages/invenio_records_rest/schemas/json.py:14: DeprecationWarning: The '__version_info__' attribute is deprecated and will be removed in in a future version. Use feature detection or 'packaging.Version(importlib.metadata.version("marshmallow")).release' instead.
  from marshmallow import __version_info__ as marshmallow_version

/opt/invenio/var/instance/python/lib/python3.9/site-packages/invenio_records_rest/schemas/fields/generated.py:13: DeprecationWarning: The '__version_info__' attribute is deprecated and will be removed in in a future version. Use feature detection or 'packaging.Version(importlib.metadata.version("marshmallow")).release' instead.
  from marshmallow import __version_info__ as marshmallow_version
  ```