### PR TITLE
i18n: Fix untranslated strings in facets

### DIFF
--- a/invenio_records_rest/config.py
+++ b/invenio_records_rest/config.py
@@ -9,17 +9,12 @@
 """Invenio-Records-REST configuration."""
 
 from flask import request
+from invenio_i18n import lazy_gettext as _
 from invenio_indexer.api import RecordIndexer
 from invenio_search import RecordsSearch
 
 from .facets import terms_filter
 from .utils import allow_all, check_search, deny_all
-
-
-def _(x):
-    """Identity function for string extraction."""
-    return x
-
 
 RECORDS_REST_ENDPOINTS = dict(
     recid=dict(

--- a/invenio_records_rest/errors.py
+++ b/invenio_records_rest/errors.py
@@ -14,6 +14,7 @@ All error classes in this module are inheriting from
 """
 
 from flask import request
+from invenio_i18n import gettext as _
 from invenio_rest.errors import FieldError, RESTException, RESTValidationError
 
 
@@ -41,7 +42,14 @@ class InvalidQueryRESTError(RESTException):
     """Invalid query syntax."""
 
     code = 400
-    description = "Invalid query syntax."
+
+    # We can't use lazy_gettext for the description field because it doesn't serialize correctly to JSON.
+    # To ensure the translated description is included in JSON output, we translate it in the constructor.
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("Invalid query syntax.")
+        super().__init__(**kwargs)
 
 
 #
@@ -54,9 +62,11 @@ class StyleNotFoundRESTError(RESTException):
 
     def __init__(self, style=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("Style {style} could not be found.").format(
+            style=f'"{style}"' if style else ""
+        )
         super().__init__(**kwargs)
-        arg = f' "{style}" ' if style else " "
-        self.description = f"Style{arg}could not be found."
 
 
 #
@@ -75,21 +85,36 @@ class PIDDoesNotExistRESTError(PIDRESTException):
     """Non-existent PID."""
 
     code = 404
-    description = "PID does not exist."
+
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("PID does not exist.")
+        super().__init__(**kwargs)
 
 
 class PIDUnregisteredRESTError(PIDRESTException):
     """Unregistered PID."""
 
     code = 404
-    description = "PID is not registered."
+
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("PID is not registered.")
+        super().__init__(**kwargs)
 
 
 class PIDDeletedRESTError(PIDRESTException):
     """Deleted PID."""
 
     code = 410
-    description = "PID has been deleted."
+
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("PID has been deleted.")
+        super().__init__(**kwargs)
 
 
 class PIDMissingObjectRESTError(PIDRESTException):
@@ -99,8 +124,9 @@ class PIDMissingObjectRESTError(PIDRESTException):
 
     def __init__(self, pid, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("No object assigned to {pid}.").format(pid=pid)
         super().__init__(**kwargs)
-        self.description = f"No object assigned to {pid}."
 
 
 class PIDRedirectedRESTError(PIDRESTException):
@@ -110,9 +136,11 @@ class PIDRedirectedRESTError(PIDRESTException):
 
     def __init__(self, pid_type=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _(
+            "Invalid redirect - pid_type {pid_type} endpoint missing."
+        ).format(pid_type=f'"{pid_type}"' if pid_type else "")
         super().__init__(**kwargs)
-        arg = f' "{pid_type}" ' if pid_type else " "
-        self.description = f"Invalid redirect - pid_type{arg}endpoint missing."
 
 
 #
@@ -125,9 +153,11 @@ class PIDResolveRESTError(RESTException):
 
     def __init__(self, pid=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("PID {pid} could not be resolved.").format(
+            pid=f"#{pid}" if pid else ""
+        )
         super().__init__(**kwargs)
-        arg = f" #{pid} " if pid else " "
-        self.description = f"PID{arg}could not be resolved."
 
 
 class UnsupportedMediaRESTError(RESTException):
@@ -137,23 +167,35 @@ class UnsupportedMediaRESTError(RESTException):
 
     def __init__(self, content_type=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _('Unsupported media type "{content_type}".').format(
+            content_type=content_type or request.mimetype
+        )
         super().__init__(**kwargs)
-        content_type = content_type or request.mimetype
-        self.description = f'Unsupported media type "{content_type}".'
 
 
 class InvalidDataRESTError(RESTException):
     """Invalid request body."""
 
     code = 400
-    description = "Could not load data."
+
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("Could not load data.")
+        super().__init__(**kwargs)
 
 
 class PatchJSONFailureRESTError(RESTException):
     """Failed to patch JSON."""
 
     code = 400
-    description = "Could not patch JSON."
+
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("Could not patch JSON.")
+        super().__init__(**kwargs)
 
 
 class SuggestMissingContextRESTError(RESTException):
@@ -163,9 +205,11 @@ class SuggestMissingContextRESTError(RESTException):
 
     def __init__(self, ctx_field=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("Missing {ctx_field} context.").format(
+            ctx_field=f'"{ctx_field}"' if ctx_field else ""
+        )
         super().__init__(**kwargs)
-        arg = f' "{ctx_field}" ' if ctx_field else " "
-        self.description = f"Missing{arg}context"
 
 
 class SuggestNoCompletionsRESTError(RESTException):
@@ -175,9 +219,11 @@ class SuggestNoCompletionsRESTError(RESTException):
 
     def __init__(self, options=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("No completions requested.{options}").format(
+            options=f" (options: {options})" if options else ""
+        )
         super().__init__(**kwargs)
-        arg = f" (options: {options})" if options else ""
-        self.description = f"No completions requested.{arg}"
 
 
 class JSONSchemaValidationError(RESTValidationError):
@@ -187,13 +233,22 @@ class JSONSchemaValidationError(RESTValidationError):
 
     def __init__(self, error=None, **kwargs):
         """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _("Validation error: {error}.").format(
+            error=error.message if error else ""
+        )
         super().__init__(**kwargs)
-        error = error.message if error else ""
-        self.description = f"Validation error: {error}."
 
 
 class UnhandledSearchError(RESTException):
     """Failed to handle exception."""
 
     code = 500
-    description = "An internal server error occurred when handling the request."
+
+    def __init__(self, **kwargs):
+        """Initialize exception."""
+        if "description" not in kwargs:
+            kwargs["description"] = _(
+            "An internal server error occurred when handling the request."
+        )
+        super().__init__(**kwargs)

--- a/invenio_records_rest/errors.py
+++ b/invenio_records_rest/errors.py
@@ -64,8 +64,8 @@ class StyleNotFoundRESTError(RESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _("Style {style} could not be found.").format(
-            style=f'"{style}"' if style else ""
-        )
+                style=f'"{style}"' if style else ""
+            )
         super().__init__(**kwargs)
 
 
@@ -138,8 +138,8 @@ class PIDRedirectedRESTError(PIDRESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _(
-            "Invalid redirect - pid_type {pid_type} endpoint missing."
-        ).format(pid_type=f'"{pid_type}"' if pid_type else "")
+                "Invalid redirect - pid_type {pid_type} endpoint missing."
+            ).format(pid_type=f'"{pid_type}"' if pid_type else "")
         super().__init__(**kwargs)
 
 
@@ -155,8 +155,8 @@ class PIDResolveRESTError(RESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _("PID {pid} could not be resolved.").format(
-            pid=f"#{pid}" if pid else ""
-        )
+                pid=f"#{pid}" if pid else ""
+            )
         super().__init__(**kwargs)
 
 
@@ -168,9 +168,9 @@ class UnsupportedMediaRESTError(RESTException):
     def __init__(self, content_type=None, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _('Unsupported media type "{content_type}".').format(
-            content_type=content_type or request.mimetype
-        )
+            kwargs["description"] = _(
+                'Unsupported media type "{content_type}".'
+            ).format(content_type=content_type or request.mimetype)
         super().__init__(**kwargs)
 
 
@@ -207,8 +207,8 @@ class SuggestMissingContextRESTError(RESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _("Missing {ctx_field} context.").format(
-            ctx_field=f'"{ctx_field}"' if ctx_field else ""
-        )
+                ctx_field=f'"{ctx_field}"' if ctx_field else ""
+            )
         super().__init__(**kwargs)
 
 
@@ -221,8 +221,8 @@ class SuggestNoCompletionsRESTError(RESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _("No completions requested.{options}").format(
-            options=f" (options: {options})" if options else ""
-        )
+                options=f" (options: {options})" if options else ""
+            )
         super().__init__(**kwargs)
 
 
@@ -235,8 +235,8 @@ class JSONSchemaValidationError(RESTValidationError):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _("Validation error: {error}.").format(
-            error=error.message if error else ""
-        )
+                error=error.message if error else ""
+            )
         super().__init__(**kwargs)
 
 
@@ -249,6 +249,6 @@ class UnhandledSearchError(RESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _(
-            "An internal server error occurred when handling the request."
-        )
+                "An internal server error occurred when handling the request."
+            )
         super().__init__(**kwargs)

--- a/invenio_records_rest/errors.py
+++ b/invenio_records_rest/errors.py
@@ -63,8 +63,9 @@ class StyleNotFoundRESTError(RESTException):
     def __init__(self, style=None, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _("Style {style} could not be found.").format(
-                style=f'"{style}"' if style else ""
+            kwargs["description"] = _(
+                "Style %(style)s could not be found.",
+                style=f'"{style}"' if style else "",
             )
         super().__init__(**kwargs)
 
@@ -125,7 +126,7 @@ class PIDMissingObjectRESTError(PIDRESTException):
     def __init__(self, pid, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _("No object assigned to {pid}.").format(pid=pid)
+            kwargs["description"] = _("No object assigned to %(pid)s.", pid=pid)
         super().__init__(**kwargs)
 
 
@@ -138,8 +139,9 @@ class PIDRedirectedRESTError(PIDRESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _(
-                "Invalid redirect - pid_type {pid_type} endpoint missing."
-            ).format(pid_type=f'"{pid_type}"' if pid_type else "")
+                "Invalid redirect - pid_type %(pid_type)s endpoint missing.",
+                pid_type=f'"{pid_type}"' if pid_type else "",
+            )
         super().__init__(**kwargs)
 
 
@@ -154,8 +156,8 @@ class PIDResolveRESTError(RESTException):
     def __init__(self, pid=None, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _("PID {pid} could not be resolved.").format(
-                pid=f"#{pid}" if pid else ""
+            kwargs["description"] = _(
+                "PID %(pid)s could not be resolved.", pid=f"#{pid}" if pid else ""
             )
         super().__init__(**kwargs)
 
@@ -169,8 +171,9 @@ class UnsupportedMediaRESTError(RESTException):
         """Initialize exception."""
         if "description" not in kwargs:
             kwargs["description"] = _(
-                'Unsupported media type "{content_type}".'
-            ).format(content_type=content_type or request.mimetype)
+                'Unsupported media type "%(content_type)s".',
+                content_type=content_type or request.mimetype,
+            )
         super().__init__(**kwargs)
 
 
@@ -206,8 +209,9 @@ class SuggestMissingContextRESTError(RESTException):
     def __init__(self, ctx_field=None, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _("Missing {ctx_field} context.").format(
-                ctx_field=f'"{ctx_field}"' if ctx_field else ""
+            kwargs["description"] = _(
+                "Missing %(ctx_field)s context.",
+                ctx_field=f'"{ctx_field}"' if ctx_field else "",
             )
         super().__init__(**kwargs)
 
@@ -220,8 +224,9 @@ class SuggestNoCompletionsRESTError(RESTException):
     def __init__(self, options=None, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _("No completions requested.{options}").format(
-                options=f" (options: {options})" if options else ""
+            kwargs["description"] = _(
+                "No completions requested.%(options)s",
+                options=f" (options: {options})" if options else "",
             )
         super().__init__(**kwargs)
 
@@ -234,8 +239,8 @@ class JSONSchemaValidationError(RESTValidationError):
     def __init__(self, error=None, **kwargs):
         """Initialize exception."""
         if "description" not in kwargs:
-            kwargs["description"] = _("Validation error: {error}.").format(
-                error=error.message if error else ""
+            kwargs["description"] = _(
+                "Validation error: %(error)s.", error=error.message if error else ""
             )
         super().__init__(**kwargs)
 

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -512,8 +512,9 @@ def use_paginate_args(default_size=25, max_results=10000):
                 raise SearchPaginationRESTError(
                     description=(
                         _(
-                            "Maximum number of {count} results have been reached."
-                        ).format(count=_max_results)
+                            "Maximum number of %(count)s results have been reached.",
+                            count=_max_results,
+                        )
                     )
                 )
 

--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -438,7 +438,7 @@ def need_record_permission(factory_name):
 def _validate_pagination_args(args):
     if args.get("page") and args.get("from"):
         raise WebargsValidationError(
-            "The query parameters from and page must not be " "used at the same time.",
+            _("The query parameters from and page must not be used at the same time."),
             field_names=["page", "from"],
         )
 
@@ -475,7 +475,7 @@ def use_paginate_args(default_size=25, max_results=10000):
             # For validation errors, webargs raises an enhanced BadRequest
             except BadRequest as err:
                 raise SearchPaginationRESTError(
-                    description="Invalid pagination parameters.",
+                    description=_("Invalid pagination parameters."),
                     errors=err.data.get("messages"),
                 )
 
@@ -511,9 +511,9 @@ def use_paginate_args(default_size=25, max_results=10000):
             if req["to_idx"] > _max_results:
                 raise SearchPaginationRESTError(
                     description=(
-                        "Maximum number of {} results have been reached.".format(
-                            _max_results
-                        )
+                        _(
+                            "Maximum number of {count} results have been reached."
+                        ).format(count=_max_results)
                     )
                 )
 
@@ -595,7 +595,7 @@ class RecordsListResource(ContentNegotiatedMethodView):
         record_class=None,
         indexer_class=None,
         search_query_parser=None,
-        **kwargs
+        **kwargs,
     ):
         """Constructor."""
         super().__init__(
@@ -608,7 +608,7 @@ class RecordsListResource(ContentNegotiatedMethodView):
                 "POST": default_media_type,
             },
             default_media_type=default_media_type,
-            **kwargs
+            **kwargs,
         )
         self.pid_type = pid_type
         self.minter = current_pidstore.minters[minter_name]
@@ -762,7 +762,7 @@ class RecordResource(ContentNegotiatedMethodView):
         loaders=None,
         search_class=None,
         indexer_class=None,
-        **kwargs
+        **kwargs,
     ):
         """Constructor."""
         super().__init__(
@@ -778,7 +778,7 @@ class RecordResource(ContentNegotiatedMethodView):
                 "PATCH": default_media_type,
             },
             default_media_type=default_media_type,
-            **kwargs
+            **kwargs,
         )
         self.search_class = search_class
         self.read_permission_factory = read_permission_factory

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -24,6 +24,6 @@ trap cleanup EXIT
 python -m check_manifest
 python -m sphinx.cmd.build -qnN docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
-python -m pytest
+python -m pytest $@
 tests_exit_code=$?
 exit "$tests_exit_code"


### PR DESCRIPTION
### Description

Fix: some strings that could appear inside UI were not marked with `gettext/lazy_gettext`.

This PR adds `lazy_gettext` into places where the string is read when invenio is started (static initialization) and `gettext` elsewhere

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
