### PR TITLE
views: preserve file system keys during record PUT

### DIFF
--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -925,8 +925,13 @@ class RecordResource(ContentNegotiatedMethodView):
 
         self.check_etag(str(record.revision_id))
 
+        # Preserve internal system keys (e.g. file bucket references)
+        # that must survive a full metadata replacement.
+        _system_keys = ('_bucket', '_files')
+        preserved = {k: record[k] for k in _system_keys if k in record}
         record.clear()
         record.update(data)
+        record.update(preserved)
         record.commit()
         db.session.commit()
         if self.indexer_class:

--- a/tests/test_views_item_put.py
+++ b/tests/test_views_item_put.py
@@ -151,6 +151,43 @@ def test_invalid_put(app, search, test_records, charset, search_url):
         assert res.status_code == 412
 
 
+def test_put_preserves_system_keys(app, search, test_records, search_class):
+    """Test that PUT preserves _bucket and _files keys (invenio/invenio#3989).
+
+    When a record has file-related system keys (_bucket, _files), a PUT
+    that replaces the metadata must not discard those keys.
+    """
+    HEADERS = [
+        ("Accept", "application/json"),
+        ("Content-Type", "application/json"),
+    ]
+
+    pid, record = test_records[0]
+
+    fake_bucket = "deadbeef-dead-dead-dead-deaddeadbeef"
+    fake_files = [{"key": "test.txt", "size": 42}]
+    record["_bucket"] = fake_bucket
+    record["_files"] = fake_files
+    record.commit()
+
+    from invenio_db import db
+
+    db.session.commit()
+
+    with app.test_client() as client:
+        url = record_url(pid)
+
+        updated_data = {"title": "Updated title", "year": 9999}
+        res = client.put(url, data=json.dumps(updated_data), headers=HEADERS)
+        assert res.status_code == 200
+
+        result = get_json(res)["metadata"]
+        assert result["title"] == "Updated title"
+        assert result["year"] == 9999
+        assert result["_bucket"] == fake_bucket
+        assert result["_files"] == fake_files
+
+
 @mock.patch("invenio_records.api.Record.commit", _mock_validate_fail)
 @pytest.mark.parametrize(
     "content_type", ["application/json", "application/json;charset=utf-8"]


### PR DESCRIPTION
## Summary

- Fixes silent data loss where `_bucket` and `_files` keys are wiped when updating a record via `PUT /api/records/<id>`
- Adds a regression test that verifies system keys survive a full metadata replacement

## Root Cause

The `PUT` handler at `views.py:928` calls `record.clear()` followed by `record.update(data)`. This discards internal system keys like `_bucket` and `_files` that are set by `invenio-records-files` when files are attached to a record. After a PUT, the record loses its bucket reference and all file associations -- silently, with no error.

## Fix

Before clearing, the handler now preserves `_bucket` and `_files` keys and restores them after the update:

```python
_system_keys = ('_bucket', '_files')
preserved = {k: record[k] for k in _system_keys if k in record}
record.clear()
record.update(data)
record.update(preserved)
```

This is a minimal, targeted fix. A more comprehensive approach would be to define a `Record.SYSTEM_KEYS` class attribute, but that would be a larger refactor best done separately.

## Test plan

- [x] New test `test_put_preserves_system_keys` verifies `_bucket` and `_files` survive PUT
- [x] Existing PUT tests still pass (metadata replacement, ETag, deleted records, validation)
- [ ] Maintainers: confirm no other system keys need preservation

Fixes inveniosoftware/invenio#3989