### PR TITLE
fix(views): accept weak ETags in If-Match for nginx+gzip compatibility

### DIFF
--- a/invenio_records_rest/views.py
+++ b/invenio_records_rest/views.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2015-2019 CERN.
 # SPDX-FileCopyrightText: 2023-2026 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 RERO.
 # SPDX-License-Identifier: MIT
 
 """REST API resources."""
@@ -827,7 +828,7 @@ class RecordResource(ContentNegotiatedMethodView):
         :param pid: Persistent identifier for record.
         :param record: Record object.
         """
-        self.check_etag(str(record.model.version_id))
+        self.check_etag(str(record.model.version_id), weak=True)
 
         record.delete()
         # mark all PIDs as DELETED
@@ -864,7 +865,7 @@ class RecordResource(ContentNegotiatedMethodView):
         :returns: The requested record.
         """
         etag = str(record.revision_id)
-        self.check_etag(str(record.revision_id))
+        self.check_etag(str(record.revision_id), weak=True)
         self.check_if_modified_since(record.updated, etag=etag)
 
         return self.make_response(pid, record, links_factory=self.links_factory)
@@ -898,7 +899,7 @@ class RecordResource(ContentNegotiatedMethodView):
         if data is None:
             raise InvalidDataRESTError()
 
-        self.check_etag(str(record.revision_id))
+        self.check_etag(str(record.revision_id), weak=True)
         try:
             record = record.patch(data)
         except (JsonPatchException, JsonPointerException):
@@ -941,7 +942,7 @@ class RecordResource(ContentNegotiatedMethodView):
         if data is None:
             raise InvalidDataRESTError()
 
-        self.check_etag(str(record.revision_id))
+        self.check_etag(str(record.revision_id), weak=True)
 
         record.clear()
         record.update(data)

--- a/tests/test_views_item_put.py
+++ b/tests/test_views_item_put.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2015-2018 CERN.
+# SPDX-FileCopyrightText: 2026 RERO.
 # SPDX-License-Identifier: MIT
 
 """Record PUT tests."""
@@ -65,6 +66,31 @@ def test_valid_put_etag(
         IndexFlusher(search_class).flush_and_wait()
         res = client.get(search_url, query_string={"year": 1234})
         assert_hits_len(res, 1)
+
+
+def test_valid_put_weak_etag(app, search, test_records):
+    """Test that a weak ETag in If-Match is accepted (nginx+gzip compatibility).
+
+    When nginx compresses a response it converts the ETag from strong ("N") to
+    weak (W/"N"). Clients that round-trip this value in If-Match must not
+    receive a 412: check_etag is called with weak=True so that W/"N" and "N"
+    are both accepted for a version-counter ETag.
+    """
+    pid, record = test_records[0]
+    record["year"] = 1234
+
+    with app.test_client() as client:
+        url = record_url(pid)
+        res = client.put(
+            url,
+            data=json.dumps(record.dumps()),
+            headers={
+                "Content-Type": "application/json",
+                "If-Match": 'W/"{0}"'.format(record.revision_id),
+            },
+        )
+        assert res.status_code == 200
+        assert get_json(client.get(url))["metadata"]["year"] == 1234
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
ETags in invenio are version counters (record.revision_id), not content
hashes. When nginx compresses responses it downgrades strong ETags ("N")
to weak ones (W/"N") because gzip changes the byte sequence. Clients
that round-trip the received ETag in If-Match were getting a silent 412
or, worse, a bypassed precondition check.

Pass weak=True to check_etag in all four handlers (delete, get, patch,
put) so that both W/"N" and "N" are accepted. This is correct because
the strong/weak distinction is only meaningful for content-derived ETags;
a version counter identifies resource state unambiguously regardless of
transfer encoding.

Co-Authored-by: Johnny Mariéthoz <johnny.mariethoz@rero.ch>

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
